### PR TITLE
cargo: Bump version to 0.2.0-jinx5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "jinko"
-version = "0.2.1-jinx4"
+version = "0.2.0-jinx5"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jinko"
-version = "0.2.1-jinx4"
+version = "0.2.0-jinx5"
 authors = ["CohenArthur <arthur.cohen@epita.fr>", "Skallwar <esteban.blanc@epita.fr>", "SanderJSA <sander.julien-saint-amand@epita.fr"]
 edition = "2018"
 description = "jinko is a safe, small and fast programming language with Rust interoperability"


### PR DESCRIPTION
Last "code" release before actual 0.2.0 release