### PR TITLE
Parse and instantiate empty types

### DIFF
--- a/.github/workflows/build_test_fmt.yml
+++ b/.github/workflows/build_test_fmt.yml
@@ -68,14 +68,3 @@ jobs:
       run: |
           cargo install --git https://github.com/cohenarthur/ft
           tests/func_tests.sh
-
-#  test-publish:
-#    runs-on: ubuntu-latest
-#    needs: [build, build-without-warnings, tests, functional_tests]
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Check if jinko is release ready
-#      uses: katyo/publish-crates@v1
-#      with:
-#        dry-run: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,4 +18,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
-

--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -26,6 +26,7 @@ mod type_id;
 mod type_instantiation;
 mod var;
 mod var_assignment;
+mod var_or_empty_type;
 
 pub use binary_op::BinaryOp;
 pub use block::Block;
@@ -45,6 +46,7 @@ pub use type_id::{TypeId, PRIMITIVE_TYPES};
 pub use type_instantiation::TypeInstantiation;
 pub use var::Var;
 pub use var_assignment::VarAssign;
+pub use var_or_empty_type::VarOrEmptyType;
 
 /// The type of instructions available. An Instruction either is a statement, or an
 /// expression. An expression contains an instance of a result. For example,

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -51,13 +51,24 @@ impl Instruction for VarOrEmptyType {
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         let symbol_type_id = TypeId::new(self.symbol.clone());
         match ctx.get_type(&symbol_type_id) {
-            Some(ty) => {
+            Some(_) => {
                 let ty_inst = TypeInstantiation::new(symbol_type_id);
                 ty_inst.execute(ctx)
             }
             None => {
                 let var_inst = Var::new(self.symbol.clone());
                 var_inst.execute(ctx)
+            }
+        }
+    }
+
+    fn as_bool(&self, ctx: &mut Context) -> Option<bool> {
+        let symbol_type_id = TypeId::new(self.symbol.clone());
+        match ctx.get_type(&symbol_type_id) {
+            Some(_) => None,
+            None => {
+                let var_inst = Var::new(self.symbol.clone());
+                var_inst.as_bool(ctx)
             }
         }
     }

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -1,0 +1,80 @@
+use crate::{
+    instruction::{TypeId, TypeInstantiation, Var},
+    CheckedType, Context, InstrKind, Instruction, ObjectInstance, TypeCheck, TypeCtx,
+};
+
+#[derive(Clone, PartialEq)]
+enum Kind {
+    Unknown,
+    EmptyTypeInst,
+    VarAccess,
+}
+
+#[derive(Clone)]
+pub struct VarOrEmptyType {
+    kind: Kind,
+    symbol: String,
+}
+
+impl VarOrEmptyType {
+    pub fn new(symbol: String) -> VarOrEmptyType {
+        VarOrEmptyType {
+            kind: Kind::Unknown,
+            symbol,
+        }
+    }
+
+    fn resolve_kind(&self, ctx: &mut TypeCtx) -> Kind {
+        let resolved = ctx.get_custom_type(&self.symbol);
+        if resolved.is_some() {
+            return Kind::EmptyTypeInst;
+        }
+
+        let resolved = ctx.get_var(&self.symbol);
+        if resolved.is_some() {
+            return Kind::VarAccess;
+        }
+
+        Kind::Unknown
+    }
+}
+
+impl Instruction for VarOrEmptyType {
+    fn kind(&self) -> InstrKind {
+        InstrKind::Expression(None)
+    }
+
+    fn print(&self) -> String {
+        self.symbol.clone()
+    }
+
+    fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
+        let symbol_type_id = TypeId::new(self.symbol.clone());
+        match ctx.get_type(&symbol_type_id) {
+            Some(ty) => {
+                let ty_inst = TypeInstantiation::new(symbol_type_id);
+                ty_inst.execute(ctx)
+            }
+            None => {
+                let var_inst = Var::new(self.symbol.clone());
+                var_inst.execute(ctx)
+            }
+        }
+    }
+}
+
+impl TypeCheck for VarOrEmptyType {
+    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+        let kind = if self.kind == Kind::Unknown {
+            self.resolve_kind(ctx)
+        } else {
+            self.kind.clone()
+        };
+
+        match kind {
+            Kind::Unknown => CheckedType::Unknown,
+            Kind::EmptyTypeInst => CheckedType::Resolved(TypeId::new(self.symbol.clone())),
+            Kind::VarAccess => ctx.get_var(&self.symbol).unwrap().to_owned(),
+        }
+    }
+}

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -15,14 +15,19 @@
 
 use nom::Err::Error as NomError;
 use nom::{
-    branch::alt, combinator::{opt, peek}, multi::many0, sequence::delimited, sequence::pair,
-    sequence::preceded, sequence::terminated,
+    branch::alt,
+    combinator::{opt, peek},
+    multi::many0,
+    sequence::delimited,
+    sequence::pair,
+    sequence::preceded,
+    sequence::terminated,
 };
 
 use crate::instruction::{
     BinaryOp, Block, DecArg, FieldAccess, FunctionCall, FunctionDec, FunctionKind, IfElse, Incl,
     Instruction, JkInst, Loop, LoopKind, MethodCall, Operator, Return, TypeDec, TypeId,
-    TypeInstantiation, Var, VarAssign,
+    TypeInstantiation, Var, VarAssign, VarOrEmptyType,
 };
 use crate::parser::{ConstantConstruct, ParseResult, Token};
 
@@ -405,7 +410,7 @@ fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instru
         let (input, value) = expr(input)?;
         Ok((input, Box::new(VarAssign::new(false, id, value))))
     } else if let Ok((input, _)) = peek(Token::semicolon)(input) {
-        Ok((input, Box::new(TypeInstantiation::new(TypeId::new(id)))))
+        Ok((input, Box::new(VarOrEmptyType::new(id))))
     } else {
         Ok((input, Box::new(Var::new(id))))
     }

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -15,13 +15,8 @@
 
 use nom::Err::Error as NomError;
 use nom::{
-    branch::alt,
-    combinator::{opt, peek},
-    multi::many0,
-    sequence::delimited,
-    sequence::pair,
-    sequence::preceded,
-    sequence::terminated,
+    branch::alt, combinator::opt, multi::many0, sequence::delimited, sequence::pair,
+    sequence::preceded, sequence::terminated,
 };
 
 use crate::instruction::{
@@ -397,10 +392,9 @@ fn inner_block(input: &str) -> ParseResult<&str, Block> {
     Ok((input, block))
 }
 
-/// func_type_or_var = [ '<' IDENTIFIER ( ',' IDENTIFIER )* '>' ] '(' next func_or_type_inst_args
+/// func_type_or_var = '(' next func_or_type_inst_args
 ///                  | '=' expr                   (* variable assigment *)
-///                  | ';'                        (* empty type instantiation *)
-///                  | ε                          (* variable *)
+///                  | ε                          (* variable or empty type instantiation *)
 fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instruction>> {
     if let Ok((input, _)) = Token::left_bracket(input) {
         generic_func_or_type_inst_args(next(input), id)
@@ -409,10 +403,8 @@ fn func_type_or_var(input: &str, id: String) -> ParseResult<&str, Box<dyn Instru
     } else if let Ok((input, _)) = Token::equal(input) {
         let (input, value) = expr(input)?;
         Ok((input, Box::new(VarAssign::new(false, id, value))))
-    } else if let Ok((input, _)) = peek(Token::semicolon)(input) {
-        Ok((input, Box::new(VarOrEmptyType::new(id))))
     } else {
-        Ok((input, Box::new(Var::new(id))))
+        Ok((input, Box::new(VarOrEmptyType::new(id))))
     }
 }
 

--- a/stdlib/maybe.jk
+++ b/stdlib/maybe.jk
@@ -3,7 +3,7 @@
 
 // TODO: Implement Maybe<T> once generics are implemented
 // TODO: Implement Maybe<T> as multi-type once they are implemented
-type Maybe_int(inner: int, is_some: bool)
+type Maybe_int(inner: int, is_some: bool);
 
 func is_some(m: Maybe_int) -> bool {
     m.is_some

--- a/stdlib/pair.jk
+++ b/stdlib/pair.jk
@@ -4,7 +4,7 @@
 /**
  * The Pair type holds two instances of two types, which may or may not be different.
  */
-type Pair_int(f: int, s: int)
+type Pair_int(f: int, s: int);
 
 /**
  * Create a new pair from two instances of types T and U

--- a/tests/ft/type_checking/invalid/empty_types.jk
+++ b/tests/ft/type_checking/invalid/empty_types.jk
@@ -1,0 +1,5 @@
+type Ok;
+type NotOk;
+
+mut o = Ok;
+o = NotOk; // tc error

--- a/tests/ft/type_checking/typecheck.yml
+++ b/tests/ft/type_checking/typecheck.yml
@@ -87,3 +87,12 @@ tests:
     args:
       - "tests/ft/type_checking/invalid/return_in_if_else.jk"
     exit_code: 1
+  - name: "Valid empty types"
+    binary: "target/debug/jinko"
+    args:
+      - "tests/ft/type_checking/valid/empty_types.jk"
+  - name: "Invalid empty types"
+    binary: "target/debug/jinko"
+    args:
+      - "tests/ft/type_checking/invalid/empty_types.jk"
+    exit_code: 1

--- a/tests/ft/type_checking/valid/empty_types.jk
+++ b/tests/ft/type_checking/valid/empty_types.jk
@@ -9,3 +9,9 @@ o = Ok;
 func takes_ok(o: Ok) {}
 
 o.takes_ok()
+Ok.takes_ok()
+{ Ok }.takes_ok()
+
+func return_ok() -> Ok {
+    Ok
+}

--- a/tests/ft/type_checking/valid/empty_types.jk
+++ b/tests/ft/type_checking/valid/empty_types.jk
@@ -1,0 +1,11 @@
+type Empty;
+e = Empty;
+
+type Ok;
+type NotOk;
+
+o = Ok;
+
+func takes_ok(o: Ok) {}
+
+o.takes_ok()


### PR DESCRIPTION
The issue we are facing right now is differentiating between variables
and empty types instantiation. For example, `a = Type;` is no different,
parser wise, from `a = b;`. We can differentiate this later on during
typechecking or find another solution here
