### PR TITLE
Add Args.count()

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -97,6 +97,10 @@ fn arg_get(ctx: &mut Context, args: Args) -> Option<ObjectInstance> {
     Some(JkString::from(result_string).to_instance())
 }
 
+fn arg_amount(ctx: &mut Context, _args: Args) -> Option<ObjectInstance> {
+    Some(JkInt::from(ctx.args().len() as i64).to_instance())
+}
+
 /// Exit the interpreter with a given exit code
 fn exit(ctx: &mut Context, args: Args) -> Option<ObjectInstance> {
     let exit_code = JkInt::from_instance(&args[0].execute(ctx).unwrap()).0;
@@ -124,6 +128,7 @@ impl Builtins {
         builtins.add("__builtin_string_equals", string_equals);
         builtins.add("__builtin_ffi_link_with", ffi_link_with);
         builtins.add("__builtin_arg_get", arg_get);
+        builtins.add("__builtin_arg_amount", arg_amount);
         builtins.add("__builtin_exit", exit);
 
         builtins
@@ -171,6 +176,7 @@ mod tests {
     fn t_args_builtins_are_valid() {
         jinko! {
             __builtin_arg_get(158);
+            amount = __builtin_arg_amount();
         };
     }
 

--- a/stdlib/args.jk
+++ b/stdlib/args.jk
@@ -1,4 +1,5 @@
 ext func __builtin_arg_get(arg_index: int) -> string;
+ext func __builtin_arg_amount() -> int;
 
 // FIXME: This should become an empty type
 type Args(__fixme: int);
@@ -12,4 +13,8 @@ func args() -> Args {
 // For now, this returns an empty string
 func at(a: Args, index: int) -> string {
     __builtin_arg_get(index)
+}
+
+func amount(a: Args) -> int {
+    __builtin_arg_amount()
 }

--- a/stdlib/args.jk
+++ b/stdlib/args.jk
@@ -1,13 +1,7 @@
 ext func __builtin_arg_get(arg_index: int) -> string;
 ext func __builtin_arg_amount() -> int;
 
-// FIXME: This should become an empty type
-type Args(__fixme: int);
-
-// FIXME: This should do more
-func args() -> Args {
-    Args(__fixme: 0)
-}
+type Args;
 
 // FIXME: This should return a Maybe<string> once that is implemented.
 // For now, this returns an empty string

--- a/tests/ft/stdlib/args.jk
+++ b/tests/ft/stdlib/args.jk
@@ -1,3 +1,1 @@
-args = args();
-
-len(args.at(0))
+len(Args.at(0))


### PR DESCRIPTION
- parser: WIP: Parse empty types -> Read message
- empty_types: Add empty type parsing and instantiation
- empty_types: Instantiate empty types on the fly
- stdlib: Add Args.count() function
- stdlib: Make Args type an empty type
