### PR TITLE
Allow function calls as booleans

### DIFF
--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -4,8 +4,8 @@
 use crate::instruction::{FunctionDec, FunctionKind, Var};
 use crate::typechecker::TypeCtx;
 use crate::{
-    typechecker::CheckedType, Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance,
-    TypeCheck,
+    typechecker::CheckedType, Context, ErrKind, Error, FromObjectInstance, InstrKind, Instruction,
+    JkBool, ObjectInstance, TypeCheck,
 };
 use std::rc::Rc;
 
@@ -185,6 +185,20 @@ impl Instruction for FunctionCall {
         ctx.scope_exit();
 
         ret_val
+    }
+
+    fn as_bool(&self, ctx: &mut Context) -> Option<bool> {
+        self.execute(ctx).map(|instance| match instance.ty() {
+            CheckedType::Resolved(ty) => match ty.id() {
+                // FIXME:
+                "bool" => JkBool::from_instance(&instance).as_bool(ctx).unwrap(),
+                // We can safely unwrap since we checked the type of the variable
+                // FIXME: Is this correct?
+                _ => unreachable!(),
+            },
+            // FIXME: Is this correct?
+            _ => unreachable!(),
+        })
     }
 }
 

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -42,6 +42,13 @@ impl Instruction for MethodCall {
 
         call.execute(ctx)
     }
+
+    fn as_bool(&self, ctx: &mut Context) -> Option<bool> {
+        let mut call = self.method.clone();
+        call.add_arg_front(self.var.clone());
+
+        call.as_bool(ctx)
+    }
 }
 
 impl TypeCheck for MethodCall {


### PR DESCRIPTION
- parser: WIP: Parse empty types -> Read message
- empty_types: Add empty type parsing and instantiation
- empty_types: Instantiate empty types on the fly
- functions: Allow as_bool() on function calls and method calls
