### PR TITLE
Add simple logging system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "anyhow",
  "colored",
  "downcast-rs",
+ "lazy_static",
  "libc",
  "libloading",
  "linefeed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ linefeed = "0.6"
 downcast-rs = "1.2"
 anyhow = "1.0"
 libloading = "0.7"
+lazy_static = "1.4"
 
 [dev-dependencies]
 libc = "0.2"

--- a/interpreter/jinko.rs
+++ b/interpreter/jinko.rs
@@ -99,14 +99,13 @@ fn handle_input(args: &Args, file: &Path) -> InteractResult {
 
     ctx.set_path(Some(file.to_owned()));
     ctx.set_args(args.project_args());
-    ctx.set_debug(args.debug());
 
     ctx.emit_errors();
     ctx.clear_errors();
 
     match args.test() {
         false => match args.interactive() {
-            true => Repl::new(args)?.with_context(ctx).launch(),
+            true => Repl::new()?.with_context(ctx).launch(),
             false => {
                 let res = ctx.execute()?;
                 ctx.emit_errors();
@@ -129,9 +128,12 @@ fn handle_input(args: &Args, file: &Path) -> InteractResult {
 
 fn main() -> anyhow::Result<()> {
     let args = Args::handle();
+    if args.debug() {
+        jinko::log::enable();
+    }
 
     let result = args.input().map_or_else(
-        || Repl::new(&args)?.launch(),
+        || Repl::new()?.launch(),
         |filename| handle_input(&args, filename),
     )?;
 

--- a/interpreter/repl.rs
+++ b/interpreter/repl.rs
@@ -6,7 +6,7 @@ use prompt::Prompt;
 use std::path::PathBuf;
 
 use jinko::{
-    log, constructs, Context, Error, FromObjectInstance, Instruction, JkConstant, ObjectInstance,
+    constructs, log, Context, Error, FromObjectInstance, Instruction, JkConstant, ObjectInstance,
 };
 use jinko::{CheckedType, TypeCheck, TypeCtx};
 

--- a/interpreter/repl.rs
+++ b/interpreter/repl.rs
@@ -6,11 +6,11 @@ use prompt::Prompt;
 use std::path::PathBuf;
 
 use jinko::{
-    constructs, Context, Error, FromObjectInstance, Instruction, JkConstant, ObjectInstance,
+    log, constructs, Context, Error, FromObjectInstance, Instruction, JkConstant, ObjectInstance,
 };
 use jinko::{CheckedType, TypeCheck, TypeCtx};
 
-use crate::{Args, InteractResult};
+use crate::InteractResult;
 
 use linefeed::{DefaultTerminal, Interface, ReadResult};
 
@@ -36,13 +36,12 @@ impl std::fmt::Display for ReplInstance {
     }
 }
 
-pub struct Repl<'args> {
-    args: &'args Args,
+pub struct Repl {
     ctx: Option<Context>,
     reader: Interface<DefaultTerminal>,
 }
 
-impl<'args> Repl<'args> {
+impl Repl {
     /// Parse a new instruction from the user's input. This function uses the parser's
     /// `instruction` method, and can therefore parse any valid Jinko instruction
     fn parse_instruction(input: &str) -> Result<Option<Box<dyn Instruction>>, Error> {
@@ -55,23 +54,21 @@ impl<'args> Repl<'args> {
         }
     }
 
-    pub fn new(args: &Args) -> std::io::Result<Repl> {
+    pub fn new() -> std::io::Result<Repl> {
         Ok(Repl {
-            args,
             ctx: None,
             reader: Interface::new("jinko")?,
         })
     }
 
-    pub fn with_context(self, ctx: Context) -> Repl<'args> {
+    pub fn with_context(self, ctx: Context) -> Repl {
         Repl {
             ctx: Some(ctx),
             ..self
         }
     }
 
-    fn setup_context(args: &Args, ctx: &mut Context) {
-        ctx.set_debug(args.debug());
+    fn setup_context(ctx: &mut Context) {
         ctx.set_path(Some(PathBuf::from("repl")));
 
         let ep = ctx.entry_point.block().unwrap().clone();
@@ -88,12 +85,14 @@ impl<'args> Repl<'args> {
 
     /// Launch the REPL
     pub fn launch(self) -> InteractResult {
+        log!("starting REPL");
+
         let mut ctx = match self.ctx {
             Some(ctx) => ctx,
             None => Context::new(),
         };
 
-        Repl::setup_context(self.args, &mut ctx);
+        Repl::setup_context(&mut ctx);
 
         self.reader.set_prompt(&Prompt::get(&ctx))?;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -150,11 +150,6 @@ impl Context {
         self.error_handler.clear();
     }
 
-    /// Set the debug mode of a previously created ctx
-    pub fn set_debug(&mut self, debug: bool) {
-        self.debug_mode = debug
-    }
-
     /// Add a function to the context. Returns `Ok` if the function was added, `Err`
     /// if it existed already and was not.
     pub fn add_function(&mut self, function: FunctionDec) -> Result<(), Error> {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,6 +3,7 @@
 //! FIXME
 
 use crate::instruction::{FunctionCall, FunctionDec};
+use crate::log;
 use crate::{
     Context, ErrKind, Error, FromObjectInstance, JkInt, JkString, ObjectInstance, ToObjectInstance,
 };
@@ -91,7 +92,7 @@ pub fn execute(
     call: &FunctionCall,
     ctx: &mut Context,
 ) -> Result<Option<ObjectInstance>, Error> {
-    ctx.debug("EXT CALL", call.name());
+    log!("ext call: {}", call.name());
     let sym = call.name().as_bytes();
 
     // FIXME: Don't unwrap

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -7,9 +7,10 @@
 
 use crate::{
     instruction::{Operator, TypeId},
+    log,
     typechecker::{CheckedType, TypeCtx},
     Context, ErrKind, Error, FromObjectInstance, InstrKind, Instruction, JkFloat, JkInt,
-    ObjectInstance, TypeCheck, Value,
+    ObjectInstance, TypeCheck, Value
 };
 
 /// The `BinaryOp` struct contains two expressions and an operator, which can be an arithmetic
@@ -76,9 +77,7 @@ impl Instruction for BinaryOp {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug_step("BINOP ENTER");
-
-        ctx.debug("OP", self.op.as_str());
+        log!("binop enter: op: {}", self.op.as_str());
 
         let l_value = self.execute_node(&*self.lhs, ctx)?;
         let r_value = self.execute_node(&*self.rhs, ctx)?;
@@ -114,7 +113,7 @@ impl Instruction for BinaryOp {
             ),
         }
 
-        ctx.debug_step("BINOP EXIT");
+        log!("BINOP EXIT");
 
         Some(return_value)
     }

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -10,7 +10,7 @@ use crate::{
     log,
     typechecker::{CheckedType, TypeCtx},
     Context, ErrKind, Error, FromObjectInstance, InstrKind, Instruction, JkFloat, JkInt,
-    ObjectInstance, TypeCheck, Value
+    ObjectInstance, TypeCheck, Value,
 };
 
 /// The `BinaryOp` struct contains two expressions and an operator, which can be an arithmetic

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -18,6 +18,7 @@
 //! Otherwise, it's `void`
 
 use crate::{
+    log,
     typechecker::{CheckedType, TypeCtx},
     Context, InstrKind, Instruction, ObjectInstance, TypeCheck,
 };
@@ -98,7 +99,7 @@ impl Instruction for Block {
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         ctx.scope_enter();
-        ctx.debug_step("BLOCK ENTER");
+        log!("block enter");
 
         let ret_val = self
             .instructions
@@ -107,7 +108,7 @@ impl Instruction for Block {
             .last();
 
         ctx.scope_exit();
-        ctx.debug_step("BLOCK EXIT");
+        log!("block exit");
 
         match self.is_statement {
             false => ret_val.flatten(),

--- a/src/instruction/extra_content.rs
+++ b/src/instruction/extra_content.rs
@@ -54,7 +54,7 @@ impl ExtraContent {
 
 impl Instruction for ExtraContent {
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("COMMENT", self.print().as_str());
+        log!("comment: {}", self.print().as_str());
 
         None
     }

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -2,6 +2,7 @@
 //! FIXME: Add doc
 
 use crate::{
+    log,
     typechecker::{CheckedType, TypeCtx},
     Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, TypeCheck,
 };
@@ -57,11 +58,11 @@ impl Instruction for FieldAccess {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("FIELD ACCESS ENTER", &self.print());
+        log!("field access enter: {}", &self.print());
 
         let field_instance = self.get_field_instance(ctx);
 
-        ctx.debug("FIELD ACCESS EXIT", &self.print());
+        log!("field access exit: {}", &self.print());
 
         field_instance
     }

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 #[derive(Clone)]
 pub struct FunctionCall {
     fn_name: String,
-    generics: Vec<TypeId>,
+    _generics: Vec<TypeId>,
     args: Vec<Box<dyn Instruction>>,
 }
 
@@ -25,7 +25,7 @@ impl FunctionCall {
     ) -> FunctionCall {
         FunctionCall {
             fn_name,
-            generics,
+            _generics: generics,
             args,
         }
     }

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -4,8 +4,8 @@
 use crate::instruction::{FunctionDec, FunctionKind, TypeId, Var};
 use crate::typechecker::TypeCtx;
 use crate::{
-    typechecker::CheckedType, Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance,
-    TypeCheck,
+    log, typechecker::CheckedType, Context, ErrKind, Error, InstrKind,
+    Instruction, ObjectInstance, TypeCheck,
 };
 use std::rc::Rc;
 
@@ -64,9 +64,9 @@ impl FunctionCall {
     /// Map each argument to its corresponding instruction
     fn map_args(&self, function: &FunctionDec, ctx: &mut Context) {
         for (call_arg, func_arg) in self.args.iter().zip(function.args()) {
-            ctx.debug(
-                "VAR MAP",
-                format!("Mapping `{}` to `{}`", func_arg.name(), call_arg.print()).as_ref(),
+            log!(
+                "var map: {}",
+                format!("mapping `{}` to `{}`", func_arg.name(), call_arg.print()),
             );
 
             // Create a new variable, and execute the content of the function argument
@@ -182,7 +182,7 @@ impl Instruction for FunctionCall {
 
         ctx.scope_enter();
 
-        ctx.debug("CALL", self.name());
+        log!("call: {}", self.name());
 
         self.map_args(&function, ctx);
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -4,8 +4,8 @@
 use crate::instruction::{FunctionDec, FunctionKind, TypeId, Var};
 use crate::typechecker::TypeCtx;
 use crate::{
-    log, typechecker::CheckedType, Context, ErrKind, Error, InstrKind,
-    Instruction, ObjectInstance, TypeCheck,
+    log, typechecker::CheckedType, Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance,
+    TypeCheck,
 };
 use std::rc::Rc;
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -3,7 +3,7 @@
 
 use crate::instruction::{Block, DecArg, InstrKind, Instruction, TypeId};
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{Context, ErrKind, Error, ObjectInstance, TypeCheck};
+use crate::{log, Context, ErrKind, Error, ObjectInstance, TypeCheck};
 
 /// What "kind" of function is defined. There are four types of functions in jinko,
 /// the normal ones, the external ones, the unit tests and the mocks
@@ -129,7 +129,7 @@ impl Instruction for FunctionDec {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug_step("FUNCDEC ENTER");
+        log!("funcdec enter: {}", self.name());
 
         match self.fn_kind() {
             FunctionKind::Func | FunctionKind::Ext => {
@@ -148,7 +148,7 @@ impl Instruction for FunctionDec {
             ),
         }
 
-        ctx.debug_step("FUNCDEC EXIT");
+        log!("funcdec exit: {}", self.name());
 
         None
     }

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -19,8 +19,8 @@ use crate::instance::FromObjectInstance;
 use crate::instruction::{Block, InstrKind, Instruction, TypeId};
 use crate::typechecker::TypeCtx;
 use crate::value::JkBool;
+use crate::{log, ErrKind, Error};
 use crate::{typechecker::CheckedType, Context, ObjectInstance, TypeCheck};
-use crate::{ErrKind, Error};
 
 #[derive(Clone)]
 pub struct IfElse {
@@ -61,16 +61,15 @@ impl Instruction for IfElse {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug_step("IF_ELSE ENTER");
+        log!("if_else enter");
 
         let cond = self.condition.execute(ctx)?;
-        // ctx.debug("COND", &cond.to_string());
 
         if JkBool::from_instance(&cond).rust_value() {
-            ctx.debug_step("IF ENTER");
+            log!("if enter");
             self.if_body.execute(ctx)
         } else {
-            ctx.debug_step("ELSE ENTER");
+            log!("else enter");
             match &self.else_body {
                 Some(b) => b.execute(ctx),
                 // FIXME: Fix logic: If an `if` returns something, the else should too.

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -4,6 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
+    log,
     parser::constructs,
     typechecker::{CheckedType, TypeCtx},
     Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, TypeCheck,
@@ -81,7 +82,7 @@ impl Incl {
             return Ok((formatted, vec![]));
         }
 
-        ctx.debug("FINAL PATH", &format!("{:?}", formatted));
+        log!("final path: {}", &format!("{:?}", formatted));
 
         let input = std::fs::read_to_string(&formatted)?;
 
@@ -201,12 +202,12 @@ impl Instruction for Incl {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("INCL ENTER", self.print().as_str());
+        log!("incl enter: {}", self.print().as_str());
 
         let base = self.get_base(ctx);
         let _prefix = self.format_prefix()?;
 
-        ctx.debug("BASE DIR", &format!("{:#?}", base));
+        log!("base dir: {}", &format!("{:#?}", base));
 
         let old_path = ctx.path().cloned();
 
@@ -218,8 +219,6 @@ impl Instruction for Incl {
         content.iter_mut().for_each(|instr| {
             // FIXME: Rework prefixing
             // instr.prefix(&prefix);
-
-            ctx.debug("INCLUDING", instr.print().as_str());
 
             instr.execute(ctx);
         });

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -5,7 +5,7 @@
 
 use crate::instruction::{FunctionCall, InstrKind, Instruction};
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{Context, ErrKind, Error, ObjectInstance, TypeCheck};
+use crate::{log, Context, ErrKind, Error, ObjectInstance, TypeCheck};
 
 /// The potential ctx instructions
 #[derive(Clone, Debug, PartialEq)]
@@ -59,7 +59,7 @@ impl Instruction for JkInst {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("JINKO_INST", &self.print());
+        log!("jinko_inst: {}", &self.print());
 
         match self.kind {
             JkInstKind::Dump => println!("{}", ctx.print()),

--- a/src/instruction/loop_block.rs
+++ b/src/instruction/loop_block.rs
@@ -3,7 +3,7 @@
 
 use crate::instruction::{Block, FunctionCall, InstrKind, Instruction, Var};
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{Context, FromObjectInstance, JkBool, ObjectInstance, TypeCheck};
+use crate::{log, Context, FromObjectInstance, JkBool, ObjectInstance, TypeCheck};
 
 /// What kind of loop the loop block represents: Either a for Loop, with a variable and
 /// a range expression, a while loop with just an upper bound, or a loop with no bound
@@ -52,19 +52,20 @@ impl Instruction for Loop {
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         match &self.kind {
             LoopKind::Loop => loop {
-                ctx.debug_step("LOOP ENTER");
+                log!("loop enter");
                 self.block.execute(ctx)?;
-                ctx.debug_step("LOOP EXIT");
+                log!("loop exit");
             },
             LoopKind::While(cond) => {
-                ctx.debug_step("WHILE ENTER");
                 let cond = cond.execute(ctx)?;
+                log!("while enter");
                 while JkBool::from_instance(&cond).rust_value() {
                     self.block.execute(ctx)?;
                 }
-                ctx.debug_step("WHILE EXIT");
+                log!("while exit");
             }
             LoopKind::For(var, range_expression) => {
+                log!("foreach enter");
                 // Let's break down the implementation for the following loop
                 // ```
                 // for i in range(0, 10) { /* exec() */ }
@@ -183,6 +184,7 @@ impl Instruction for Loop {
                 }
 
                 ctx.scope_exit();
+                log!("foreach exit");
             }
         }
 

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -3,7 +3,7 @@
 
 use crate::instruction::FunctionCall;
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{Context, InstrKind, Instruction, ObjectInstance, TypeCheck};
+use crate::{log, Context, InstrKind, Instruction, ObjectInstance, TypeCheck};
 
 #[derive(Clone)]
 pub struct MethodCall {
@@ -29,16 +29,16 @@ impl Instruction for MethodCall {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("METHOD CALL ENTER", &self.print());
+        log!("method call enter: {}", &self.print());
 
         // FIXME: No clone here
         let mut call = self.method.clone();
 
         call.add_arg_front(self.var.clone());
 
-        ctx.debug("DESUGARING TO", &call.print());
+        log!("desugaring to: {}", &call.print());
 
-        ctx.debug("METHOD CALL EXIT", &self.print());
+        log!("method call exit: {}", &self.print());
 
         call.execute(ctx)
     }

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -1,6 +1,7 @@
 use super::{DecArg, InstrKind, Instruction, TypeId};
 
 use crate::{
+    log,
     typechecker::{CheckedType, TypeCtx},
     Context, ObjectInstance, TypeCheck,
 };
@@ -39,14 +40,14 @@ impl Instruction for TypeDec {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug_step(&format!("CUSTOM TYPE {} ENTER", self.name));
+        log!("custom type enter: {}", self.name);
 
         if let Err(e) = ctx.add_type(self.clone()) {
             ctx.error(e);
             return None;
         }
 
-        ctx.debug_step(&format!("CUSTOM TYPE {} EXIT", self.name));
+        log!("custom type enter: {}", self.name);
 
         // Declaring a type is always a statement (for now)
         None

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -4,6 +4,7 @@
 //! or it's not.
 
 use crate::instruction::TypeDec;
+use crate::log;
 use crate::typechecker::{CheckedType, TypeCtx};
 use crate::{Context, ErrKind, Error, InstrKind, Instruction, ObjectInstance, TypeCheck};
 
@@ -81,7 +82,7 @@ impl Instruction for Var {
             }
         };
 
-        ctx.debug("VAR", var.print().as_ref());
+        log!("var: {}", var.print());
 
         Some(var.instance())
     }

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -2,7 +2,7 @@
 
 use crate::instruction::{InstrKind, Var};
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{Context, ErrKind, Error, Instruction, ObjectInstance, TypeCheck};
+use crate::{log, Context, ErrKind, Error, Instruction, ObjectInstance, TypeCheck};
 
 #[derive(Clone)]
 pub struct VarAssign {
@@ -55,7 +55,7 @@ impl Instruction for VarAssign {
     }
 
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("ASSIGN VAR", self.symbol());
+        log!("assign var: {}", self.symbol());
 
         // Are we creating the variable or not
         let mut var_creation = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod ffi;
 mod indent;
 pub mod instance;
 pub mod instruction;
+pub mod log;
 pub mod parser;
 pub mod typechecker;
 mod utils;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,24 @@
+static mut ENABLED: bool = false;
+
+pub fn enable() {
+    unsafe { ENABLED = true; }
+}
+
+pub fn disable() {
+    unsafe { ENABLED = true; }
+}
+
+pub fn is_enabled() -> bool {
+    unsafe { ENABLED }
+}
+
+#[macro_export]
+macro_rules! log {
+    ($($token:tt)*) => (
+        if $crate::log::is_enabled() {
+            use colored::Colorize;
+
+            eprintln!("<{}> {}", "LOG".on_purple(), format_args!($($token)*));
+        }
+    );
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,20 +1,20 @@
 use lazy_static::lazy_static;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 lazy_static! {
-    static ref ENABLED: Mutex<bool> = Mutex::new(false);
+    static ref ENABLED: AtomicBool = AtomicBool::new(false);
 }
 
 pub fn enable() {
-    *ENABLED.lock().unwrap() = true;
+    ENABLED.store(true, Ordering::Relaxed);
 }
 
 pub fn disable() {
-    *ENABLED.lock().unwrap() = true;
+    ENABLED.store(false, Ordering::Relaxed);
 }
 
 pub fn is_enabled() -> bool {
-    *ENABLED.lock().unwrap()
+    ENABLED.load(Ordering::Relaxed)
 }
 
 #[macro_export]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,19 +1,20 @@
-static mut ENABLED: bool = false;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref ENABLED: Mutex<bool> = Mutex::new(false);
+}
 
 pub fn enable() {
-    unsafe {
-        ENABLED = true;
-    }
+    *ENABLED.lock().unwrap() = true;
 }
 
 pub fn disable() {
-    unsafe {
-        ENABLED = true;
-    }
+    *ENABLED.lock().unwrap() = true;
 }
 
 pub fn is_enabled() -> bool {
-    unsafe { ENABLED }
+    *ENABLED.lock().unwrap()
 }
 
 #[macro_export]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,11 +1,15 @@
 static mut ENABLED: bool = false;
 
 pub fn enable() {
-    unsafe { ENABLED = true; }
+    unsafe {
+        ENABLED = true;
+    }
 }
 
 pub fn disable() {
-    unsafe { ENABLED = true; }
+    unsafe {
+        ENABLED = true;
+    }
 }
 
 pub fn is_enabled() -> bool {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,7 +2,7 @@
 //! entry is created for the "main" function of the program. Including modules adds
 //! instructions to that main entry.
 
-use crate::{Context, Error, log};
+use crate::{log, Context, Error};
 
 mod constant_construct;
 pub mod constructs;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,7 +2,7 @@
 //! entry is created for the "main" function of the program. Including modules adds
 //! instructions to that main entry.
 
-use crate::{Context, Error};
+use crate::{Context, Error, log};
 
 mod constant_construct;
 pub mod constructs;
@@ -16,6 +16,7 @@ pub type ParseResult<T, I> = nom::IResult<T, I, Error>;
 /// Parses the entire user input and returns a hashmap corresponding to the user
 /// program
 pub fn parse(ctx: &mut Context, input: &str) -> Result<(), Error> {
+    log!("parsing file: {:?}", ctx.path());
     let entry_block = ctx.entry_point.block_mut().unwrap();
 
     let (_, instructions) = constructs::many_expr(input)?;

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -1,7 +1,7 @@
 use crate::instruction::{InstrKind, Instruction, Operator, TypeId};
 use crate::typechecker::{CheckedType, TypeCheck, TypeCtx};
 use crate::{
-    Context, Error, FromObjectInstance, JkString, ObjectInstance, ToObjectInstance, Value,
+    log, Context, Error, FromObjectInstance, JkString, ObjectInstance, ToObjectInstance, Value,
 };
 
 use std::convert::TryFrom;
@@ -101,8 +101,8 @@ macro_rules! jk_primitive {
                 self.0.to_string()
             }
 
-            fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-                ctx.debug("CONSTANT", &self.0.to_string());
+            fn execute(&self, _ctx: &mut Context) -> Option<ObjectInstance> {
+                log!("constant: {}", &self.0.to_string());
 
                 // Since we cannot use the generic ToObjectInstance implementation, we also have to
                 // copy paste our four basic implementations for jinko's primitive types...
@@ -203,8 +203,8 @@ macro_rules! jk_primitive {
                 self.0.to_string()
             }
 
-            fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-                ctx.debug("CONSTANT", &self.0.to_string());
+            fn execute(&self, _ctx: &mut Context) -> Option<ObjectInstance> {
+                log!("constant: {}", &self.0.to_string());
 
                 // Since we cannot use the generic ToObjectInstance implementation, we also have to
                 // copy paste our four basic implementations for jinko's primitive types...
@@ -287,8 +287,8 @@ impl Instruction for JkString {
         format!("\"{}\"", self.0.clone())
     }
 
-    fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
-        ctx.debug("CONSTANT", &self.0.to_string());
+    fn execute(&self, _ctx: &mut Context) -> Option<ObjectInstance> {
+        log!("constant: {}", &self.0.to_string());
 
         Some(self.to_instance())
     }


### PR DESCRIPTION
- log: Add basic logging macro
- ctx: Remove set_debug() function
- log: Replace ctx.debugs() with simple logging

Closes #64 

This enables various passes to not rely on the context for logging anymore. It's currently very simple, but we could think about improving it later on