### PR TITLE
Format string on parsing

### DIFF
--- a/src/parser/constant_construct.rs
+++ b/src/parser/constant_construct.rs
@@ -4,9 +4,13 @@
 //! to be used by high level Construct functions. It is very similar to BoxConstruct in
 //! that sense.
 
-use crate::instruction::Instruction;
+use super::constructs::expr;
+use crate::instruction::{FunctionCall, Instruction, MethodCall};
 use crate::parser::{ParseResult, Token};
-use crate::{JkBool, JkChar, JkFloat, JkInt, JkString};
+use crate::{ErrKind, Error, JkBool, JkChar, JkFloat, JkInt, JkString};
+
+use nom::sequence::terminated;
+use nom::Err::Error as NomError;
 
 pub struct ConstantConstruct;
 
@@ -18,10 +22,37 @@ impl ConstantConstruct {
         Ok((input, Box::new(JkChar::from(char_value))))
     }
 
-    pub(crate) fn string_constant(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
-        let (input, string_value) = Token::string_constant(input)?;
+    pub(crate) fn string_constant(mut input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
+        let mut ast: Box<dyn Instruction> = Box::new(JkString::from(""));
+        let special: &[_] = &['"', '{'];
+        while !input.is_empty() {
+            if let Ok((input, _)) = Token::double_quote(input) {
+                return Ok((input, ast));
+            }
+            if let Ok((new_input, _)) = Token::left_curly_bracket(input) {
+                let (new_input, expr) = terminated(expr, Token::right_curly_bracket)(new_input)?;
+                ast = ConstantConstruct::format_expr(ast, expr);
+                input = new_input;
+            } else if let Some(index) = input.find(special) {
+                ast = Box::new(JkString::from(&input[..index]));
+                input = &input[index..];
+            } else {
+                break;
+            }
+        }
+        Err(NomError(
+            Error::new(ErrKind::Parsing).with_msg(String::from("Undelimited string")),
+        ))
+    }
 
-        Ok((input, Box::new(JkString::from(string_value))))
+    fn format_expr(
+        string: Box<dyn Instruction>,
+        expr: Box<dyn Instruction>,
+    ) -> Box<dyn Instruction> {
+        Box::new(MethodCall::new(
+            string,
+            FunctionCall::new(String::from("concat"), vec![], vec![expr]),
+        ))
     }
 
     pub(crate) fn float_constant(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
@@ -40,5 +71,43 @@ impl ConstantConstruct {
         let (input, bool_value) = Token::bool_constant(input)?;
 
         Ok((input, Box::new(JkBool::from(bool_value))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_string() {
+        let input = "hello\"";
+
+        let (input, expr) = ConstantConstruct::string_constant(input).unwrap();
+        assert_eq!(input, "");
+        let string = expr.downcast_ref::<JkString>().unwrap();
+        assert_eq!(string.0, "hello");
+    }
+
+    #[test]
+    fn formatted_once() {
+        let input = "hello {world}\"";
+
+        let (input, expr) = ConstantConstruct::string_constant(input).unwrap();
+        assert_eq!(input, "");
+        assert!(expr.downcast_ref::<MethodCall>().is_some());
+    }
+
+    #[test]
+    fn formatted_not_delimited() {
+        let input = "hello {world}";
+
+        assert!(ConstantConstruct::string_constant(input).is_err());
+    }
+
+    #[test]
+    fn basic_not_delimited() {
+        let input = "Rust Transmute Task Force";
+
+        assert!(ConstantConstruct::string_constant(input).is_err());
     }
 }

--- a/src/parser/constant_construct.rs
+++ b/src/parser/constant_construct.rs
@@ -129,6 +129,15 @@ mod tests {
     }
 
     #[test]
+    fn formatted_start() {
+        let input = "\"{10 + 9} is 21\"";
+
+        let (input, expr) = ConstantConstruct::string_constant(input).unwrap();
+        assert_eq!(input, "");
+        assert!(expr.downcast_ref::<MethodCall>().is_some());
+    }
+
+    #[test]
     fn formatted_not_delimited() {
         let input = "\"hello {world}";
 

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -555,7 +555,7 @@ fn nom_next(input: &str) -> ParseResult<&str, ()> {
 pub(crate) fn constant(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
     let constant = alt((
         ConstantConstruct::char_constant,
-        ConstantConstruct::string_constant,
+        preceded(Token::double_quote, ConstantConstruct::string_constant),
         ConstantConstruct::float_constant,
         ConstantConstruct::int_constant,
         ConstantConstruct::bool_constant,

--- a/src/parser/constructs.rs
+++ b/src/parser/constructs.rs
@@ -555,7 +555,7 @@ fn nom_next(input: &str) -> ParseResult<&str, ()> {
 pub(crate) fn constant(input: &str) -> ParseResult<&str, Box<dyn Instruction>> {
     let constant = alt((
         ConstantConstruct::char_constant,
-        preceded(Token::double_quote, ConstantConstruct::string_constant),
+        ConstantConstruct::string_constant,
         ConstantConstruct::float_constant,
         ConstantConstruct::int_constant,
         ConstantConstruct::bool_constant,

--- a/src/parser/grammar
+++ b/src/parser/grammar
@@ -27,7 +27,7 @@ unit = 'if' expr block next [ 'else' next block ]
      | 'true'
      | 'false'
      | "'" CHAR "'"
-     | '"' [^"] '"'
+     | '"' string
      | INT
      | DOUBLE
      | IDENTIFIER next func_type_or_var
@@ -73,3 +73,7 @@ extra = WHITESPACE
       | '/*' [^'*/'] '*/'
       | '//' [^\n] '\n'
       | '#'  [^\n] '\n'
+
+string = '"'
+       | '{' expr '}' string
+       | CHAR string

--- a/src/parser/grammar
+++ b/src/parser/grammar
@@ -27,7 +27,7 @@ unit = 'if' expr block next [ 'else' next block ]
      | 'true'
      | 'false'
      | "'" CHAR "'"
-     | '"' string
+     | '"' inner_string
      | INT
      | DOUBLE
      | IDENTIFIER next func_type_or_var
@@ -74,6 +74,6 @@ extra = WHITESPACE
       | '//' [^\n] '\n'
       | '#'  [^\n] '\n'
 
-string = '"'
-       | '{' expr '}' string
-       | CHAR string
+inner_string = '"'
+             | '{' expr '}' string
+             | CHAR string


### PR DESCRIPTION
This PR formats string at parse time instead of eval time,
here's an example change in behavior caused by this PR:
before:
```
my_str = "{wont_fail}"
wont_fail = 10
println(my_str)
```
after:
```
my_str = "{will_fail}"
will_fail = 10
println(my_str)
```
The big difference it this string is now formatted in the context where it is ***built*** instead on where it is ***called***.


I'm not sure if/what could I should remove to disable de eval time formatting though.