### PR TITLE
Add eval funtion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]

--- a/examples/simple-repl.rs
+++ b/examples/simple-repl.rs
@@ -9,13 +9,14 @@ fn main() -> Result<()> {
     let mut input = String::new();
 
     loop {
+        ctx.clear_errors();
         print!("> ");
         stdout.flush()?;
 
         input.clear();
         stdin.read_line(&mut input)?;
 
-        // ctx.eval(input);
+        ctx.eval(&input);
 
         print!("{}", input);
     }


### PR DESCRIPTION
In order to make repl.jinko.ml to work correctly, we need to have an `eval` function. 

For now I think that `Context` is a good home. But I will let this in draft until the code architecture refactor is done.

We also need to figure out how we want to be able to log error and ouptut somewhere else than `stdout` and `stderr`

