### PR TITLE
typechecker: WIP Move TypeCtx inside Context structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,10 +41,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -61,10 +108,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users 0.3.5",
+ "winapi",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users 0.4.0",
+ "winapi",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "heck"
@@ -93,7 +216,9 @@ dependencies = [
  "downcast-rs",
  "lazy_static",
  "libc",
- "nom",
+ "libloading",
+ "linefeed",
+ "nom 7.1.0",
  "structopt",
 ]
 
@@ -110,6 +235,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
+name = "libloading"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
+name = "linefeed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28715d08e35c6c074f9ae6b2e6a2420bac75d050c66ecd669d7d5b98e2caa036"
+dependencies = [
+ "dirs 1.0.5",
+ "mortal",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +268,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mortal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998fd6a991497275567703b6f435e27958b633878ec991f5734b96dd46675e9f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "nix",
+ "smallstr",
+ "terminfo",
+ "unicode-normalization",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +316,50 @@ dependencies = [
  "minimal-lexical",
  "version_check",
 ]
+
+[[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -175,6 +404,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall 0.2.10",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
+name = "smallstr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e922794d168678729ffc7e07182721a14219c65814e66e91b839a272fe5ae4f"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,12 +565,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
+dependencies = [
+ "dirs 2.0.2",
+ "fnv",
+ "nom 5.1.2",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -253,6 +639,24 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/interpreter/repl.rs
+++ b/interpreter/repl.rs
@@ -6,7 +6,8 @@ use prompt::Prompt;
 use std::path::PathBuf;
 
 use jinko::{
-    constructs, log, Context, Error, FromObjectInstance, Instruction, JkConstant, ObjectInstance, CheckedType
+    constructs, log, CheckedType, Context, Error, FromObjectInstance, Instruction, JkConstant,
+    ObjectInstance,
 };
 
 use crate::InteractResult;

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -171,7 +171,7 @@ impl Default for Builtins {
 
 #[cfg(test)]
 mod tests {
-    use crate::{jinko, jinko_fail};
+    use crate::jinko;
 
     #[test]
     fn t_string_builtins_are_valid() {
@@ -196,6 +196,8 @@ mod tests {
     #[test]
     #[cfg(not(feature = "ffi"))]
     fn t_ffi_builtins_are_valid_no_ffi() {
+        use crate::jinko_fail;
+
         jinko_fail! {
             __builtin_ffi_link_with("tests/fixtures/clib/lib.so");
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -128,7 +128,10 @@ impl Context {
 
     /// Get a reference to a context's source path
     pub fn set_path(&mut self, path: Option<PathBuf>) {
-        self.path = path;
+        // FIXME: Remove that clone...
+        self.path = path.clone();
+        self.typechecker.set_path(path);
+
         // FIXME: Is that correct? Remove that clone()...
         self.error_handler
             .set_path(self.path.clone().unwrap_or_default());

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,9 +17,9 @@ use std::rc::Rc;
 
 use crate::error::{ErrKind, Error, ErrorHandler};
 use crate::instruction::{Block, FunctionDec, FunctionKind, Instruction, TypeDec, TypeId, Var};
-use crate::typechecker::{TypeCtx, TypeCheck};
-use crate::{Builtins, CheckedType};
+use crate::typechecker::{TypeCheck, TypeCtx};
 use crate::ObjectInstance;
+use crate::{Builtins, CheckedType};
 
 /// Type the context uses for keys
 type CtxKey = String;
@@ -273,7 +273,8 @@ impl Context {
     pub fn type_check(&mut self, instruction: &dyn Instruction) -> Result<CheckedType, Error> {
         let res = instruction.resolve_type(&mut self.typechecker);
 
-        self.error_handler.append(&mut self.typechecker.error_handler);
+        self.error_handler
+            .append(&mut self.typechecker.error_handler);
 
         match self.error_handler.has_errors() {
             true => Err(Error::new(ErrKind::TypeChecker)),
@@ -288,7 +289,14 @@ impl Context {
         self.scope_enter();
 
         ep.resolve_type(&mut self.typechecker);
-        self.error_handler.append(&mut self.typechecker.error_handler);
+        self.error_handler
+            .append(&mut self.typechecker.error_handler);
+        self.emit_errors();
+
+        if self.has_errors() {
+            return Err(Error::new(ErrKind::TypeChecker));
+        };
+
         self.included.clear();
 
         let res = ep

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,8 +17,8 @@ use std::rc::Rc;
 
 use crate::error::{ErrKind, Error, ErrorHandler};
 use crate::instruction::{Block, FunctionDec, FunctionKind, Instruction, TypeDec, TypeId, Var};
-use crate::typechecker::TypeCtx;
-use crate::Builtins;
+use crate::typechecker::{TypeCtx, TypeCheck};
+use crate::{Builtins, CheckedType};
 use crate::ObjectInstance;
 
 /// Type the context uses for keys
@@ -63,6 +63,9 @@ pub struct Context {
 
     /// Errors being kept by the context
     pub(crate) error_handler: ErrorHandler,
+
+    /// Various passes ran by the context
+    typechecker: TypeCtx,
 }
 
 impl Default for Context {
@@ -95,6 +98,7 @@ impl Context {
             #[cfg(feature = "ffi")]
             external_libs: Vec::new(),
             error_handler: ErrorHandler::default(),
+            typechecker: TypeCtx::new(),
         };
 
         ctx.scope_enter();
@@ -266,20 +270,14 @@ impl Context {
         self.included.remove(source);
     }
 
-    fn type_check(&mut self, entry_point: &Block) -> Result<(), Error> {
-        let mut ctx = TypeCtx::new(self);
+    pub fn type_check(&mut self, instruction: &dyn Instruction) -> Result<CheckedType, Error> {
+        let res = instruction.resolve_type(&mut self.typechecker);
 
-        entry_point.instructions().iter().for_each(|inst| {
-            inst.resolve_type(&mut ctx);
-        });
+        self.error_handler.append(&mut self.typechecker.error_handler);
 
-        self.included.clear();
         match self.error_handler.has_errors() {
-            true => {
-                self.emit_errors();
-                Err(Error::new(ErrKind::TypeChecker))
-            }
-            false => Ok(()),
+            true => Err(Error::new(ErrKind::TypeChecker)),
+            false => Ok(res),
         }
     }
 
@@ -289,7 +287,9 @@ impl Context {
 
         self.scope_enter();
 
-        self.type_check(&ep)?;
+        ep.resolve_type(&mut self.typechecker);
+        self.error_handler.append(&mut self.typechecker.error_handler);
+        self.included.clear();
 
         let res = ep
             .instructions()

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -25,6 +25,12 @@ impl ErrorHandler {
         self.errors.push(err)
     }
 
+    /// Drains all the errors contained in another handler in order to accumulate them
+    /// in one place
+    pub fn append(&mut self, other: &mut ErrorHandler) {
+        self.errors.append(&mut other.errors)
+    }
+
     /// Remove all the errors contained in the handler
     pub fn clear(&mut self) {
         self.errors.clear()

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -242,9 +242,8 @@ mod tests {
             .1;
 
         let mut ctx = Context::new();
-        let mut ctx = TypeCtx::new(&mut ctx);
 
-        assert_eq!(b.resolve_type(&mut ctx), CheckedType::Void)
+        assert_eq!(ctx.type_check(b.as_ref()).unwrap(), CheckedType::Void)
     }
 
     #[test]

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -283,7 +283,7 @@ mod tests {
 
         let f_call = FunctionCall::new("func0".to_string(), vec![], vec![]);
 
-        assert_eq!(ctx.type_check(&f_call).unwrap(), CheckedType::Unknown);
+        assert!(ctx.type_check(&f_call).is_err());
         assert!(
             ctx.error_handler.has_errors(),
             "Given 0 arguments to 2 arguments function"
@@ -293,7 +293,7 @@ mod tests {
         let f_call =
             FunctionCall::new("func0".to_string(), vec![], vec![Box::new(JkInt::from(12))]);
 
-        assert_eq!(ctx.type_check(&f_call).unwrap(), CheckedType::Unknown);
+        assert!(ctx.type_check(&f_call).is_err());
         assert!(
             ctx.error_handler.has_errors(),
             "Given 1 arguments to 2 arguments function"

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -282,19 +282,18 @@ mod tests {
         };
 
         let f_call = FunctionCall::new("func0".to_string(), vec![], vec![]);
-        let mut type_ctx = TypeCtx::new(&mut ctx);
 
-        assert_eq!(f_call.resolve_type(&mut type_ctx), CheckedType::Unknown);
+        assert_eq!(ctx.type_check(&f_call).unwrap(), CheckedType::Unknown);
         assert!(
-            type_ctx.context.error_handler.has_errors(),
+            ctx.error_handler.has_errors(),
             "Given 0 arguments to 2 arguments function"
         );
-        type_ctx.context.clear_errors();
+        ctx.clear_errors();
 
         let f_call =
             FunctionCall::new("func0".to_string(), vec![], vec![Box::new(JkInt::from(12))]);
 
-        assert_eq!(f_call.resolve_type(&mut type_ctx), CheckedType::Unknown);
+        assert_eq!(ctx.type_check(&f_call).unwrap(), CheckedType::Unknown);
         assert!(
             ctx.error_handler.has_errors(),
             "Given 1 arguments to 2 arguments function"

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -352,7 +352,7 @@ mod tests {
 
         let mut ctx = Context::new();
 
-        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
+        assert!(ctx.type_check(&function).is_err());
         assert!(ctx.error_handler.has_errors());
     }
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -317,9 +317,8 @@ mod tests {
         function.set_kind(FunctionKind::Ext);
 
         let mut ctx = Context::new();
-        let mut ty_ctx = TypeCtx::new(&mut ctx);
 
-        assert_eq!(function.resolve_type(&mut ty_ctx), CheckedType::Void);
+        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
         assert!(!ctx.error_handler.has_errors());
     }
 
@@ -333,9 +332,8 @@ mod tests {
         function.set_block(block);
 
         let mut ctx = Context::new();
-        let mut ty_ctx = TypeCtx::new(&mut ctx);
 
-        assert_eq!(function.resolve_type(&mut ty_ctx), CheckedType::Void);
+        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
         assert!(!ctx.error_handler.has_errors());
     }
 
@@ -353,9 +351,8 @@ mod tests {
         function.set_block(block);
 
         let mut ctx = Context::new();
-        let mut ty_ctx = TypeCtx::new(&mut ctx);
 
-        assert_eq!(function.resolve_type(&mut ty_ctx), CheckedType::Unknown);
+        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
         assert!(ctx.error_handler.has_errors());
     }
 

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -232,26 +232,28 @@ impl Instruction for Incl {
 
 impl TypeCheck for Incl {
     // FIXME: We need to not add the path to the interpreter here
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
+        // FIXME: Maybe the inclusion part should be done separately ahead of typechecking
+        // and execution?
         // FIXME: This is a lot of code in common with execute()
-        let base = self.get_base(ctx.context);
+        // let base = self.get_base(ctx.context);
 
-        let old_path = ctx.context.path().cloned();
+        // let old_path = ctx.context.path().cloned();
 
-        let (new_path, mut content) = match self.load(&base, ctx.context) {
-            None => return CheckedType::Unknown,
-            Some(tuple) => tuple,
-        };
+        // let (new_path, mut content) = match self.load(&base, ctx.context) {
+        //     None => return CheckedType::Unknown,
+        //     Some(tuple) => tuple,
+        // };
 
-        // Temporarily change the path of the context
-        ctx.context.set_path(Some(new_path));
+        // // Temporarily change the path of the context
+        // ctx.context.set_path(Some(new_path));
 
-        content.iter_mut().for_each(|instr| {
-            instr.resolve_type(ctx);
-        });
+        // content.iter_mut().for_each(|instr| {
+        //     instr.resolve_type(ctx);
+        // });
 
-        // Reset the old path before leaving the instruction
-        ctx.context.set_path(old_path);
+        // // Reset the old path before leaving the instruction
+        // ctx.context.set_path(old_path);
 
         CheckedType::Void
     }

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -68,20 +68,7 @@ impl Incl {
         }
     }
 
-    /// Parse the code and load it in the Incl's ctx
-    fn inner_load(
-        &self,
-        base: &Path,
-        ctx: &mut Context,
-    ) -> Result<(PathBuf, Vec<Box<dyn Instruction>>), Error> {
-        let formatted = self.find_include_path(base)?;
-
-        // If a source has already been included, skip it without returning
-        // an error
-        if ctx.is_included(&formatted) {
-            return Ok((formatted, vec![]));
-        }
-
+    fn load_instructions(&self, formatted: &Path) -> Result<Vec<Box<dyn Instruction>>, Error> {
         log!("final path: {}", &format!("{:?}", formatted));
 
         let input = std::fs::read_to_string(&formatted)?;
@@ -93,7 +80,7 @@ impl Incl {
 
         match remaining_input.len() {
             // The remaining input is empty: We parsed the whole file properly
-            0 => Ok((formatted, instructions)),
+            0 => Ok(instructions),
             _ => Err(Error::new(ErrKind::Parsing).with_msg(format!(
                 "error when parsing included file: {:?},\non the following input:\n{}",
                 formatted, remaining_input
@@ -101,46 +88,41 @@ impl Incl {
         }
     }
 
+    /// Parse the code and load it in the Incl's ctx
+    fn inner_load(&self, formatted: &Path) -> Result<Vec<Box<dyn Instruction>>, Error> {
+        self.load_instructions(formatted)
+    }
+
     /// Try to load code from the current path where the executable has been launched
-    fn load_relative(
-        &self,
-        base: &Path,
-        ctx: &mut Context,
-    ) -> Result<(PathBuf, Vec<Box<dyn Instruction>>), Error> {
-        self.inner_load(base, ctx)
+    fn load_relative(&self, formatted: &Path) -> Result<Vec<Box<dyn Instruction>>, Error> {
+        self.inner_load(formatted)
     }
 
     /// Try to load code from jinko's installation path
-    fn load_jinko_path(
-        &self,
-        ctx: &mut Context,
-    ) -> Result<(PathBuf, Vec<Box<dyn Instruction>>), Error> {
+    fn load_jinko_path(&self) -> Result<Vec<Box<dyn Instruction>>, Error> {
         let home = std::env::var("HOME")?;
 
         let base = PathBuf::from(format!("{}/.jinko/libs/", home));
-        self.inner_load(&base, ctx)
+        self.inner_load(&base)
     }
 
     /// Load the source code located at self.path
     ///
     /// There are two ways to look for a source file: First in the includer's path, and
     /// if not available in jinko's installation directory.
-    fn load(&self, base: &Path, ctx: &mut Context) -> Option<(PathBuf, Vec<Box<dyn Instruction>>)> {
+    fn load(&self, base: &Path) -> Result<Vec<Box<dyn Instruction>>, (Error, Error)> {
         // If we can load from the current path, we return early
-        let relative_err = match self.load_relative(base, ctx) {
-            Ok(tuple) => return Some(tuple),
+        let relative_err = match self.load_relative(base) {
+            Ok(instructions) => return Ok(instructions),
             Err(e) => e,
         };
 
-        let jk_path_err = match self.load_jinko_path(ctx) {
-            Ok(tuple) => return Some(tuple),
+        let jk_path_err = match self.load_jinko_path() {
+            Ok(instructions) => return Ok(instructions),
             Err(e) => e,
         };
 
-        ctx.error(relative_err);
-        ctx.error(jk_path_err);
-
-        None
+        Err((relative_err, jk_path_err))
     }
 
     /// Format the correct prefix to include content as. This depends on the presence
@@ -160,11 +142,11 @@ impl Incl {
         }
     }
 
-    fn get_base(&self, ctx: &mut Context) -> PathBuf {
+    fn get_base(&self, path: Option<&PathBuf>) -> PathBuf {
         // If the incl block contains a given base, return this instead
         match &self.base {
             Some(b) => b.clone(), // FIXME: Remove clone
-            None => match ctx.path() {
+            None => match path {
                 // Get the parent directory of the context's source file. We can unwrap
                 // since there's always a base
                 Some(path) => path.parent().unwrap().to_owned(),
@@ -204,17 +186,35 @@ impl Instruction for Incl {
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         log!("incl enter: {}", self.print().as_str());
 
-        let base = self.get_base(ctx);
+        let base = self.get_base(ctx.path());
         let _prefix = self.format_prefix()?;
+        let formatted = match self.find_include_path(&base) {
+            Ok(f) => f,
+            Err(e) => {
+                ctx.error(e);
+                return None;
+            }
+        };
+
+        if ctx.is_included(&formatted) {
+            return None;
+        }
 
         log!("base dir: {}", &format!("{:#?}", base));
 
         let old_path = ctx.path().cloned();
 
-        let (new_path, mut content) = self.load(&base, ctx)?;
+        let mut content = match self.load(&formatted) {
+            Ok(instructions) => instructions,
+            Err((e1, e2)) => {
+                ctx.error(e1);
+                ctx.error(e2);
+                return None;
+            }
+        };
 
         // Temporarily change the path of the context
-        ctx.set_path(Some(new_path));
+        ctx.set_path(Some(formatted));
 
         content.iter_mut().for_each(|instr| {
             // FIXME: Rework prefixing
@@ -232,28 +232,47 @@ impl Instruction for Incl {
 
 impl TypeCheck for Incl {
     // FIXME: We need to not add the path to the interpreter here
-    fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
-        // FIXME: Maybe the inclusion part should be done separately ahead of typechecking
-        // and execution?
+    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+        // TODO: Once we have proper locations for AST nodes this will no longer be necessary:
+        // We'll be able to desugar an incl block into its list of nodes, and assign each of
+        // them their proper location (path etc) so that we can visit them easily
         // FIXME: This is a lot of code in common with execute()
-        // let base = self.get_base(ctx.context);
+        let base = self.get_base(ctx.path());
+        let formatted = match self.find_include_path(&base) {
+            Ok(f) => f,
+            Err(e) => {
+                ctx.error(e);
+                return CheckedType::Unknown;
+            }
+        };
 
-        // let old_path = ctx.context.path().cloned();
+        let old_path = ctx.path().cloned();
 
-        // let (new_path, mut content) = match self.load(&base, ctx.context) {
-        //     None => return CheckedType::Unknown,
-        //     Some(tuple) => tuple,
-        // };
+        if ctx.is_included(&formatted) {
+            return CheckedType::Void;
+        }
 
-        // // Temporarily change the path of the context
-        // ctx.context.set_path(Some(new_path));
+        let mut content = match self.load(&formatted) {
+            Ok(instructions) => instructions,
+            Err((e1, e2)) => {
+                ctx.error(e1);
+                ctx.error(e2);
+                return CheckedType::Unknown;
+            }
+        };
 
-        // content.iter_mut().for_each(|instr| {
-        //     instr.resolve_type(ctx);
-        // });
+        // FIXME: Remove this clone
+        ctx.include(formatted.clone());
 
-        // // Reset the old path before leaving the instruction
-        // ctx.context.set_path(old_path);
+        // Temporarily change the path of the context
+        ctx.set_path(Some(formatted));
+
+        content.iter_mut().for_each(|instr| {
+            instr.resolve_type(ctx);
+        });
+
+        // Reset the old path before leaving the instruction
+        ctx.set_path(old_path);
 
         CheckedType::Void
     }

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -238,6 +238,9 @@ impl TypeCheck for Incl {
         // them their proper location (path etc) so that we can visit them easily
         // FIXME: This is a lot of code in common with execute()
         let base = self.get_base(ctx.path());
+
+        log!("base: {}", base.display());
+
         let formatted = match self.find_include_path(&base) {
             Ok(f) => f,
             Err(e) => {

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -322,11 +322,10 @@ mod tests {
     #[test]
     fn tc_string_type() {
         let mut ctx = Context::new();
-        let mut ctx = TypeCtx::new(&mut ctx);
         let s = JkString::from("that's a jk string");
 
         assert_eq!(
-            s.resolve_type(&mut ctx),
+            ctx.type_check(&s).unwrap(),
             CheckedType::Resolved(TypeId::from("string"))
         );
     }
@@ -334,11 +333,10 @@ mod tests {
     #[test]
     fn tc_bool_type() {
         let mut ctx = Context::new();
-        let mut ctx = TypeCtx::new(&mut ctx);
         let s = JkBool::from(false);
 
         assert_eq!(
-            s.resolve_type(&mut ctx),
+            ctx.type_check(&s).unwrap(),
             CheckedType::Resolved(TypeId::from("bool"))
         );
     }
@@ -346,11 +344,10 @@ mod tests {
     #[test]
     fn tc_i_type() {
         let mut ctx = Context::new();
-        let mut ctx = TypeCtx::new(&mut ctx);
         let s = JkInt::from(0);
 
         assert_eq!(
-            s.resolve_type(&mut ctx),
+            ctx.type_check(&s).unwrap(),
             CheckedType::Resolved(TypeId::from("int"))
         );
     }
@@ -358,11 +355,10 @@ mod tests {
     #[test]
     fn tc_f_type() {
         let mut ctx = Context::new();
-        let mut ctx = TypeCtx::new(&mut ctx);
         let s = JkFloat::from(15.4);
 
         assert_eq!(
-            s.resolve_type(&mut ctx),
+            ctx.type_check(&s).unwrap(),
             CheckedType::Resolved(TypeId::from("float"))
         );
     }


### PR DESCRIPTION
The only issue remaining with this change is figuring out how to include code properly. I think this shows that loading the code at each path from a different file is faaaar from optimal, and that maybe we should run an "inclusion pass" akin to the C preprocessor before the typechecking and execution passes. This pass would simply do nothing but append nodes to a mutable vector or to the context's entry point