### PR TITLE
scope_map: Keep index of scopemap

### DIFF
--- a/src/context/scope_map.rs
+++ b/src/context/scope_map.rs
@@ -243,6 +243,7 @@ impl<V, F, T> ScopeMap<V, F, T> {
 mod tests {
     use super::*;
     use crate::instruction::Var;
+    use crate::jinko;
 
     macro_rules! s {
         ($s:literal) => {
@@ -323,5 +324,17 @@ mod tests {
     fn t_scope_of_anything() {
         let _ = Scope::<i32, i32, String>::default();
         let _ = Scope::<(), (), ()>::default();
+    }
+
+    #[test]
+    fn blocks_with_same_vars() {
+        jinko! {
+            {
+                a = 15;
+            };
+            {
+                a = true;
+            }
+        };
     }
 }


### PR DESCRIPTION
This change allows the scope map to keep all its scopes at all times. I think this might not be the intended behavior, as it may fail when two functions use the same names for arguments. However, this is necessary for the generics pass to work properly.

Closes #444 