### PR TITLE
Keep type in instruction

### DIFF
--- a/interpreter/repl.rs
+++ b/interpreter/repl.rs
@@ -98,12 +98,12 @@ impl Repl {
                 }
             };
 
-            let inst = match inst {
+            let mut inst = match inst {
                 Some(i) => i,
                 None => continue,
             };
 
-            if ctx.type_check(&*inst).is_err() {
+            if ctx.type_check(&mut *inst).is_err() {
                 ctx.emit_errors();
                 ctx.clear_errors();
                 continue;

--- a/src/context.rs
+++ b/src/context.rs
@@ -274,8 +274,8 @@ impl Context {
         self.included.remove(source);
     }
 
-    pub fn type_check(&mut self, instruction: &dyn Instruction) -> Result<CheckedType, Error> {
-        let res = instruction.resolve_type(&mut self.typechecker);
+    pub fn type_check(&mut self, instruction: &mut dyn Instruction) -> Result<CheckedType, Error> {
+        let res = instruction.type_of(&mut self.typechecker);
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);
@@ -288,14 +288,14 @@ impl Context {
 
     pub fn execute(&mut self) -> Result<Option<ObjectInstance>, Error> {
         // The entry point always has a block
-        let ep = self.entry_point.block().unwrap().clone();
+        let mut ep = self.entry_point.block().unwrap().clone();
 
         self.scope_enter();
 
-        ep.resolve_type(&mut self.typechecker);
+        ep.type_of(&mut self.typechecker);
         ep.expand(self);
         self.typechecker.start_second_pass();
-        ep.resolve_type(&mut self.typechecker);
+        ep.type_of(&mut self.typechecker);
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -20,12 +20,18 @@ pub struct BinaryOp {
     lhs: Box<dyn Instruction>,
     rhs: Box<dyn Instruction>,
     op: Operator,
+    cached_type: Option<CheckedType>,
 }
 
 impl BinaryOp {
     /// Create a new `BinaryOp` from two instructions and an operator
     pub fn new(lhs: Box<dyn Instruction>, rhs: Box<dyn Instruction>, op: Operator) -> Self {
-        BinaryOp { lhs, rhs, op }
+        BinaryOp {
+            lhs,
+            rhs,
+            op,
+            cached_type: None,
+        }
     }
 
     /// Return the operator used by the BinaryOp
@@ -143,6 +149,14 @@ impl TypeCheck for BinaryOp {
             | Operator::NotEquals => CheckedType::Resolved(TypeId::from("bool")),
             _ => l_type,
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -126,9 +126,9 @@ impl Instruction for BinaryOp {
 }
 
 impl TypeCheck for BinaryOp {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
-        let l_type = self.lhs.resolve_type(ctx);
-        let r_type = self.rhs.resolve_type(ctx);
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+        let l_type = self.lhs.type_of(ctx);
+        let r_type = self.rhs.type_of(ctx);
 
         if l_type != r_type {
             ctx.error(Error::new(ErrKind::TypeChecker).with_msg(format!(

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -120,11 +120,11 @@ impl Instruction for Block {
 }
 
 impl TypeCheck for Block {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let last_type = self
             .instructions
-            .iter()
-            .map(|inst| inst.resolve_type(ctx))
+            .iter_mut()
+            .map(|inst| inst.type_of(ctx))
             .last()
             .unwrap_or(CheckedType::Void);
 
@@ -249,13 +249,13 @@ mod tests {
     #[test]
     #[ignore]
     fn block_no_last_tychk() {
-        let b = crate::parser::constructs::expr("{ 12; 15; a = 14; }")
+        let mut b = crate::parser::constructs::expr("{ 12; 15; a = 14; }")
             .unwrap()
             .1;
 
         let mut ctx = Context::new();
 
-        assert_eq!(ctx.type_check(b.as_ref()).unwrap(), CheckedType::Void)
+        assert_eq!(ctx.type_check(b.as_mut()).unwrap(), CheckedType::Void)
     }
 
     #[test]

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -27,6 +27,7 @@ use crate::{
 pub struct Block {
     instructions: Vec<Box<dyn Instruction>>,
     is_statement: bool,
+    cached_type: Option<CheckedType>,
 }
 
 impl Block {
@@ -36,6 +37,7 @@ impl Block {
         Block {
             instructions: Vec::new(),
             is_statement: true,
+            cached_type: None,
         }
     }
 
@@ -130,6 +132,14 @@ impl TypeCheck for Block {
             true => CheckedType::Void,
             false => last_type,
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/extra_content.rs
+++ b/src/instruction/extra_content.rs
@@ -77,7 +77,7 @@ impl Instruction for ExtraContent {
 }
 
 impl TypeCheck for ExtraContent {
-    fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> CheckedType {
         // FIXME: This should probably be removed, as well as the ExtraContent struct
         CheckedType::Void
     }

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -71,8 +71,8 @@ impl Instruction for FieldAccess {
 }
 
 impl TypeCheck for FieldAccess {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
-        let instance_ty = self.instance.resolve_type(ctx);
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+        let instance_ty = self.instance.type_of(ctx);
         let instance_ty_name = match &instance_ty {
             CheckedType::Resolved(ti) => ti.id(),
             _ => {

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -11,6 +11,7 @@ use crate::{
 pub struct FieldAccess {
     instance: Box<dyn Instruction>,
     field_name: String,
+    cached_type: Option<CheckedType>,
 }
 
 impl FieldAccess {
@@ -19,6 +20,7 @@ impl FieldAccess {
         FieldAccess {
             instance,
             field_name,
+            cached_type: None,
         }
     }
 
@@ -99,6 +101,14 @@ impl TypeCheck for FieldAccess {
                 CheckedType::Unknown
             }
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -207,7 +207,7 @@ impl Instruction for FunctionCall {
 }
 
 impl TypeCheck for FunctionCall {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         // FIXME: This function is very large and should be refactored
         let (args_type, return_type) = match ctx.get_function(self.name()) {
             Some(checked_type) => checked_type,
@@ -240,7 +240,7 @@ impl TypeCheck for FunctionCall {
         for ((expected_name, expected_ty), given_ty) in args_type.iter().zip(
             self.args
                 .iter()
-                .map(|given_arg| given_arg.clone().resolve_type(ctx)),
+                .map(|given_arg| given_arg.clone().type_of(ctx)),
         ) {
             if expected_ty != &given_ty {
                 errors.push(Error::new(ErrKind::TypeChecker).with_msg(format!(
@@ -303,19 +303,19 @@ mod tests {
             func func0(a: int, b: int) {}
         };
 
-        let f_call = FunctionCall::new("func0".to_string(), vec![], vec![]);
+        let mut f_call = FunctionCall::new("func0".to_string(), vec![], vec![]);
 
-        assert!(ctx.type_check(&f_call).is_err());
+        assert!(ctx.type_check(&mut f_call).is_err());
         assert!(
             ctx.error_handler.has_errors(),
             "Given 0 arguments to 2 arguments function"
         );
         ctx.clear_errors();
 
-        let f_call =
+        let mut f_call =
             FunctionCall::new("func0".to_string(), vec![], vec![Box::new(JkInt::from(12))]);
 
-        assert!(ctx.type_check(&f_call).is_err());
+        assert!(ctx.type_check(&mut f_call).is_err());
         assert!(
             ctx.error_handler.has_errors(),
             "Given 1 arguments to 2 arguments function"

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -14,6 +14,7 @@ pub struct FunctionCall {
     fn_name: String,
     generics: Vec<TypeId>,
     args: Vec<Box<dyn Instruction>>,
+    typechecked: bool,
 }
 
 impl FunctionCall {
@@ -27,6 +28,7 @@ impl FunctionCall {
             fn_name,
             generics,
             args,
+            typechecked: false,
         }
     }
 
@@ -254,6 +256,17 @@ impl TypeCheck for FunctionCall {
         self.type_args(args, ctx);
 
         return_type
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        match self.typechecked {
+            true => Some(&CheckedType::Void),
+            false => None,
+        }
+    }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {
+        self.typechecked = true;
     }
 }
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -210,7 +210,7 @@ impl Instruction for FunctionDec {
 }
 
 impl TypeCheck for FunctionDec {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let return_ty = match &self.ty {
             // FIXME: Remove clone?
             Some(ty) => CheckedType::Resolved(ty.clone()),
@@ -243,8 +243,8 @@ impl TypeCheck for FunctionDec {
         });
 
         // If the function has no block, trust the declaration
-        if let Some(b) = &self.block {
-            let block_ty = b.resolve_type(ctx);
+        if let Some(b) = &mut self.block {
+            let block_ty = b.type_of(ctx);
 
             if block_ty != return_ty {
                 ctx.error(Error::new(ErrKind::TypeChecker).with_msg(format!(
@@ -338,7 +338,7 @@ mod tests {
 
         let mut ctx = Context::new();
 
-        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
+        assert_eq!(ctx.type_check(&mut function).unwrap(), CheckedType::Void);
         assert!(!ctx.error_handler.has_errors());
     }
 
@@ -353,7 +353,7 @@ mod tests {
 
         let mut ctx = Context::new();
 
-        assert_eq!(ctx.type_check(&function).unwrap(), CheckedType::Void);
+        assert_eq!(ctx.type_check(&mut function).unwrap(), CheckedType::Void);
         assert!(!ctx.error_handler.has_errors());
     }
 
@@ -372,7 +372,7 @@ mod tests {
 
         let mut ctx = Context::new();
 
-        assert!(ctx.type_check(&function).is_err());
+        assert!(ctx.type_check(&mut function).is_err());
         assert!(ctx.error_handler.has_errors());
     }
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -25,6 +25,7 @@ pub struct FunctionDec {
     generics: Vec<TypeId>,
     args: Vec<DecArg>,
     block: Option<Block>,
+    typechecked: bool,
 }
 
 impl FunctionDec {
@@ -42,6 +43,7 @@ impl FunctionDec {
             generics,
             args,
             block: None,
+            typechecked: false,
         }
     }
 
@@ -261,6 +263,17 @@ impl TypeCheck for FunctionDec {
         ctx.scope_exit();
 
         CheckedType::Void
+    }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {
+        self.typechecked = true
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        match self.typechecked {
+            true => Some(&CheckedType::Void),
+            false => None,
+        }
     }
 }
 

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -84,9 +84,9 @@ impl Instruction for IfElse {
 }
 
 impl TypeCheck for IfElse {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let bool_checkedtype = CheckedType::Resolved(TypeId::from("bool"));
-        let cond_ty = self.condition.resolve_type(ctx);
+        let cond_ty = self.condition.type_of(ctx);
         if cond_ty != bool_checkedtype {
             ctx.error(Error::new(ErrKind::TypeChecker).with_msg(format!(
                 "if condition should be a boolean, not a `{}`",
@@ -94,11 +94,11 @@ impl TypeCheck for IfElse {
             )));
         }
 
-        let if_ty = self.if_body.resolve_type(ctx);
+        let if_ty = self.if_body.type_of(ctx);
         let else_ty = self
             .else_body
-            .as_ref()
-            .map(|else_body| else_body.resolve_type(ctx));
+            .as_mut()
+            .map(|else_body| else_body.type_of(ctx));
 
         match (if_ty, else_ty) {
             (CheckedType::Void, None) => CheckedType::Void,

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -28,6 +28,7 @@ pub struct IfElse {
     condition: Box<dyn Instruction>,
     if_body: Block,
     else_body: Option<Block>,
+    cached_type: Option<CheckedType>,
 }
 
 impl IfElse {
@@ -41,6 +42,7 @@ impl IfElse {
             condition,
             if_body,
             else_body,
+            cached_type: None,
         }
     }
 }
@@ -119,6 +121,14 @@ impl TypeCheck for IfElse {
                 CheckedType::Unknown
             }
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -234,7 +234,7 @@ impl Instruction for Incl {
 
 impl TypeCheck for Incl {
     // FIXME: We need to not add the path to the interpreter here
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         // TODO: Once we have proper locations for AST nodes this will no longer be necessary:
         // We'll be able to desugar an incl block into its list of nodes, and assign each of
         // them their proper location (path etc) so that we can visit them easily
@@ -273,7 +273,7 @@ impl TypeCheck for Incl {
         ctx.set_path(Some(formatted));
 
         content.iter_mut().for_each(|instr| {
-            instr.resolve_type(ctx);
+            instr.type_of(ctx);
         });
 
         // Reset the old path before leaving the instruction

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -18,6 +18,7 @@ pub struct Incl {
     path: String,
     alias: Option<String>,
     base: Option<PathBuf>,
+    typechecked: bool,
 }
 
 /// Default file that gets included when including a directory in jinko source code
@@ -29,6 +30,7 @@ impl Incl {
             path,
             alias,
             base: None,
+            typechecked: false,
         }
     }
 
@@ -278,6 +280,17 @@ impl TypeCheck for Incl {
         ctx.set_path(old_path);
 
         CheckedType::Void
+    }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {
+        self.typechecked = true
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        match self.typechecked {
+            true => Some(&CheckedType::Void),
+            false => None,
+        }
     }
 }
 

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -76,7 +76,7 @@ impl Instruction for JkInst {
 }
 
 impl TypeCheck for JkInst {
-    fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> CheckedType {
         CheckedType::Void
     }
 

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -79,6 +79,12 @@ impl TypeCheck for JkInst {
     fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
         CheckedType::Void
     }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {}
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        Some(&CheckedType::Void)
+    }
 }
 
 impl Generic for JkInst {}

--- a/src/instruction/jk_return.rs
+++ b/src/instruction/jk_return.rs
@@ -57,10 +57,10 @@ impl Instruction for Return {
 }
 
 impl TypeCheck for Return {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
-        match &self.value {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+        match &mut self.value {
             None => CheckedType::Void,
-            Some(v) => v.resolve_type(ctx),
+            Some(v) => v.type_of(ctx),
         }
     }
 

--- a/src/instruction/jk_return.rs
+++ b/src/instruction/jk_return.rs
@@ -18,12 +18,16 @@ use crate::{
 #[derive(Clone)]
 pub struct Return {
     value: Option<Box<dyn Instruction>>,
+    cached_type: Option<CheckedType>,
 }
 
 impl Return {
     /// Create a new Return instruction
     pub fn new(value: Option<Box<dyn Instruction>>) -> Return {
-        Return { value }
+        Return {
+            value,
+            cached_type: None,
+        }
     }
 }
 
@@ -58,6 +62,14 @@ impl TypeCheck for Return {
             None => CheckedType::Void,
             Some(v) => v.resolve_type(ctx),
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/loop_block.rs
+++ b/src/instruction/loop_block.rs
@@ -200,8 +200,8 @@ impl Instruction for Loop {
 }
 
 impl TypeCheck for Loop {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
-        self.block.resolve_type(ctx)
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+        self.block.type_of(ctx)
     }
 
     fn set_cached_type(&mut self, ty: CheckedType) {

--- a/src/instruction/loop_block.rs
+++ b/src/instruction/loop_block.rs
@@ -22,11 +22,16 @@ pub enum LoopKind {
 pub struct Loop {
     kind: LoopKind,
     block: Block,
+    cached_type: Option<CheckedType>,
 }
 
 impl Loop {
     pub fn new(kind: LoopKind, block: Block) -> Loop {
-        Loop { kind, block }
+        Loop {
+            kind,
+            block,
+            cached_type: None,
+        }
     }
 }
 
@@ -197,6 +202,14 @@ impl Instruction for Loop {
 impl TypeCheck for Loop {
     fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
         self.block.resolve_type(ctx)
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -51,11 +51,11 @@ impl Instruction for MethodCall {
 }
 
 impl TypeCheck for MethodCall {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let mut call = self.method.clone();
         call.add_arg_front(self.var.clone());
 
-        call.resolve_type(ctx)
+        call.type_of(ctx)
     }
 
     fn set_cached_type(&mut self, ty: CheckedType) {

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -10,12 +10,17 @@ use crate::{log, Context, InstrKind, Instruction, ObjectInstance, TypeCheck};
 pub struct MethodCall {
     var: Box<dyn Instruction>,
     method: FunctionCall,
+    cached_type: Option<CheckedType>,
 }
 
 impl MethodCall {
     /// Create a new MethodCall from a variable and an associated function
     pub fn new(var: Box<dyn Instruction>, method: FunctionCall) -> MethodCall {
-        MethodCall { var, method }
+        MethodCall {
+            var,
+            method,
+            cached_type: None,
+        }
     }
 }
 
@@ -51,6 +56,14 @@ impl TypeCheck for MethodCall {
         call.add_arg_front(self.var.clone());
 
         call.resolve_type(ctx)
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -90,7 +90,7 @@ impl Instruction for TypeDec {
 }
 
 impl TypeCheck for TypeDec {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         // TODO: FunctionDecs and TypeDec are very similar. Should we factor them together?
         let fields_ty = self
             .fields

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -11,6 +11,7 @@ pub struct TypeDec {
     name: String,
     generics: Vec<TypeId>,
     fields: Vec<DecArg>,
+    typechecked: bool,
 }
 
 impl TypeDec {
@@ -20,6 +21,7 @@ impl TypeDec {
             name,
             generics,
             fields,
+            typechecked: false,
         }
     }
 
@@ -110,6 +112,17 @@ impl TypeCheck for TypeDec {
 
         CheckedType::Void
     }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {
+        self.typechecked = true
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        match self.typechecked {
+            true => Some(&CheckedType::Void),
+            false => None,
+        }
+    }
 }
 
 impl Generic for TypeDec {}
@@ -132,6 +145,7 @@ impl From<String> for TypeDec {
             name: type_name,
             generics: vec![],
             fields: vec![],
+            typechecked: false,
         }
     }
 }

--- a/src/instruction/type_id.rs
+++ b/src/instruction/type_id.rs
@@ -16,7 +16,7 @@ pub struct TypeId {
 }
 
 impl TypeId {
-    pub fn new(id: String) -> TypeId {
+    pub const fn new(id: String) -> TypeId {
         TypeId { id }
     }
 

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -16,6 +16,7 @@ pub struct TypeInstantiation {
     type_name: TypeId,
     generics: Vec<TypeId>,
     fields: Vec<VarAssign>,
+    cached_type: Option<CheckedType>,
 }
 
 impl TypeInstantiation {
@@ -25,6 +26,7 @@ impl TypeInstantiation {
             type_name,
             generics: vec![],
             fields: vec![],
+            cached_type: None,
         }
     }
 
@@ -186,6 +188,14 @@ impl TypeCheck for TypeInstantiation {
         }
 
         CheckedType::Resolved(self.type_name.clone())
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -153,7 +153,7 @@ impl Instruction for TypeInstantiation {
 }
 
 impl TypeCheck for TypeInstantiation {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let (_, fields_ty) = match ctx.get_custom_type(self.type_name.id()) {
             Some(ty) => ty,
             None => {
@@ -171,8 +171,8 @@ impl TypeCheck for TypeInstantiation {
         let mut errors = vec![];
         for ((_, field_ty), value_ty) in fields_ty.iter().zip(
             self.fields
-                .iter()
-                .map(|var_assign| var_assign.value().resolve_type(ctx)),
+                .iter_mut()
+                .map(|var_assign| var_assign.value_mut().type_of(ctx)),
         ) {
             if field_ty != &value_ty {
                 errors.push(Error::new(ErrKind::TypeChecker).with_msg(format!(

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -92,7 +92,7 @@ impl Instruction for Var {
 }
 
 impl TypeCheck for Var {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         match ctx.get_var(self.name()) {
             Some(var_ty) => var_ty.clone(),
             None => {

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -14,6 +14,7 @@ pub struct Var {
     name: String,
     mutable: bool,
     instance: ObjectInstance,
+    cached_type: Option<CheckedType>,
 }
 
 impl Var {
@@ -23,6 +24,7 @@ impl Var {
             name,
             mutable: false,
             instance: ObjectInstance::empty(),
+            cached_type: None,
         }
     }
 
@@ -101,6 +103,14 @@ impl TypeCheck for Var {
                 CheckedType::Unknown
             }
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        self.cached_type = Some(ty)
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -14,6 +14,7 @@ pub struct VarAssign {
     symbol: String,
 
     value: Box<dyn Instruction>,
+    typechecked: bool,
 }
 
 impl VarAssign {
@@ -22,6 +23,7 @@ impl VarAssign {
             mutable,
             symbol,
             value,
+            typechecked: false,
         }
     }
 
@@ -151,6 +153,17 @@ impl TypeCheck for VarAssign {
         }
 
         CheckedType::Void
+    }
+
+    fn set_cached_type(&mut self, _ty: CheckedType) {
+        self.typechecked = true;
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        match self.typechecked {
+            true => Some(&CheckedType::Void),
+            false => None,
+        }
     }
 }
 

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -68,7 +68,7 @@ impl Instruction for VarOrEmptyType {
 }
 
 impl TypeCheck for VarOrEmptyType {
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
         let kind = if self.kind == Kind::Unknown {
             self.resolve_kind(ctx)
         } else {
@@ -86,7 +86,7 @@ impl TypeCheck for VarOrEmptyType {
         match ty {
             CheckedType::Void => self.kind = Kind::VarAccess,
             CheckedType::Resolved(_) => self.kind = Kind::EmptyTypeInst,
-            CheckedType::Unknown => unreachable!(),
+            CheckedType::Unknown => self.kind = Kind::Unknown,
         }
         self.cached_type = Some(ty);
     }

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -14,6 +14,9 @@ enum Kind {
 pub struct VarOrEmptyType {
     kind: Kind,
     symbol: String,
+    // FIXME: We can probably avoid keeping a `cached_type` and a `kind`. Only one
+    // is enough. Refactor later
+    cached_type: Option<CheckedType>,
 }
 
 impl VarOrEmptyType {
@@ -21,6 +24,7 @@ impl VarOrEmptyType {
         VarOrEmptyType {
             kind: Kind::Unknown,
             symbol,
+            cached_type: None,
         }
     }
 
@@ -76,6 +80,19 @@ impl TypeCheck for VarOrEmptyType {
             Kind::EmptyTypeInst => CheckedType::Resolved(TypeId::new(self.symbol.clone())),
             Kind::VarAccess => ctx.get_var(&self.symbol).unwrap().to_owned(),
         }
+    }
+
+    fn set_cached_type(&mut self, ty: CheckedType) {
+        match ty {
+            CheckedType::Void => self.kind = Kind::VarAccess,
+            CheckedType::Resolved(_) => self.kind = Kind::EmptyTypeInst,
+            CheckedType::Unknown => unreachable!(),
+        }
+        self.cached_type = Some(ty);
+    }
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        self.cached_type.as_ref()
     }
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -226,7 +226,7 @@ pub trait TypeCheck {
     /// Go through the context in order to figure out the type of an instruction.
     /// This function should report errors using the context, and the [`ErrKind::TypeCheck`]
     /// error kind.
-    fn resolve_type(&self, ctx: &mut TypeCtx) -> CheckedType;
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType;
 
     /// Cache the type of an instruction
     fn set_cached_type(&mut self, ty: CheckedType);
@@ -247,25 +247,6 @@ pub trait TypeCheck {
                 new_ty
             }
             Some(ty) => ty.clone(),
-        }
-    }
-}
-
-/// Some [`Instruction`]s need to have their type checked multiple times. For example, a
-/// function might be called in multiple places, by various vaiables. These instructions
-/// can "cache" their type in order to not go through the resolver each time
-pub trait CachedTypeCheck: TypeCheck {
-    /// Store the given type somewhere in order to cache it
-    fn set_type(&mut self, ty: CheckedType);
-
-    /// Return a reference to the cached type, previously stored using [`set_type()`]
-    fn get_type(&self) -> &CheckedType;
-
-    /// If the type is not known yet, compute it by going through the [`TypeCheck`]
-    /// resolver. Otherwise, fetch it from the cached instance
-    fn type_check(&mut self, ctx: &mut TypeCtx) {
-        if let CheckedType::Unknown = self.get_type() {
-            self.set_type(self.resolve_type(ctx))
         }
     }
 }

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -118,7 +118,7 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<bool> {
-            fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from("bool"))
             }
 
@@ -184,7 +184,7 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<char> {
-            fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from("char"))
             }
 
@@ -242,7 +242,7 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<$t> {
-            fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from($s))
             }
 
@@ -257,7 +257,7 @@ macro_rules! jk_primitive {
 
         impl From<$t> for JkConstant<$t> {
             fn from(rust_value: $t) -> Self {
-                JkConstant(rust_value, CheckedType::Resolved(TypeId::from("$s")))
+                JkConstant(rust_value, CheckedType::Resolved(TypeId::from($s)))
             }
         }
     };
@@ -338,7 +338,7 @@ impl Instruction for JkString {
 }
 
 impl TypeCheck for JkString {
-    fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> CheckedType {
         CheckedType::Resolved(TypeId::from("string"))
     }
 
@@ -373,10 +373,10 @@ mod tests {
     #[test]
     fn tc_string_type() {
         let mut ctx = Context::new();
-        let s = JkString::from("that's a jk string");
+        let mut s = JkString::from("that's a jk string");
 
         assert_eq!(
-            ctx.type_check(&s).unwrap(),
+            ctx.type_check(&mut s).unwrap(),
             CheckedType::Resolved(TypeId::from("string"))
         );
     }
@@ -384,10 +384,10 @@ mod tests {
     #[test]
     fn tc_bool_type() {
         let mut ctx = Context::new();
-        let s = JkBool::from(false);
+        let mut s = JkBool::from(false);
 
         assert_eq!(
-            ctx.type_check(&s).unwrap(),
+            ctx.type_check(&mut s).unwrap(),
             CheckedType::Resolved(TypeId::from("bool"))
         );
     }
@@ -395,10 +395,10 @@ mod tests {
     #[test]
     fn tc_i_type() {
         let mut ctx = Context::new();
-        let s = JkInt::from(0);
+        let mut s = JkInt::from(0);
 
         assert_eq!(
-            ctx.type_check(&s).unwrap(),
+            ctx.type_check(&mut s).unwrap(),
             CheckedType::Resolved(TypeId::from("int"))
         );
     }
@@ -406,10 +406,10 @@ mod tests {
     #[test]
     fn tc_f_type() {
         let mut ctx = Context::new();
-        let s = JkFloat::from(15.4);
+        let mut s = JkFloat::from(15.4);
 
         assert_eq!(
-            ctx.type_check(&s).unwrap(),
+            ctx.type_check(&mut s).unwrap(),
             CheckedType::Resolved(TypeId::from("float"))
         );
     }

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 /// A JkConstant represents a primitive type in Jinko. It is used in order to
 /// implement integers, floating point numbers, characters, booleans and strings, as
 /// well as raw byte values later for custom types.
-pub struct JkConstant<T: Clone>(pub(crate) T);
+pub struct JkConstant<T: Clone>(pub(crate) T, CheckedType);
 
 impl<T: Clone> JkConstant<T> {
     pub fn rust_value(&self) -> T {
@@ -93,6 +93,12 @@ macro_rules! jk_primitive {
             }
         }
 
+        impl From<bool> for JkConstant<bool> {
+            fn from(value: bool) -> JkConstant<bool> {
+                JkConstant(value, CheckedType::Resolved(TypeId::from("bool")))
+            }
+        }
+
         impl Instruction for JkConstant<bool> {
             fn kind(&self) -> InstrKind {
                 InstrKind::Expression(None)
@@ -114,6 +120,12 @@ macro_rules! jk_primitive {
         impl TypeCheck for JkConstant<bool> {
             fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from("bool"))
+            }
+
+            fn set_cached_type(&mut self, _: CheckedType) {}
+
+            fn cached_type(&self) -> Option<&CheckedType> {
+                Some(&self.1)
             }
         }
 
@@ -147,6 +159,12 @@ macro_rules! jk_primitive {
             }
         }
 
+        impl From<char> for JkConstant<char> {
+            fn from(value: char) -> JkConstant<char> {
+                JkConstant(value, CheckedType::Resolved(TypeId::from("char")))
+            }
+        }
+
         impl Instruction for JkConstant<char> {
             fn kind(&self) -> InstrKind {
                 InstrKind::Expression(None)
@@ -168,6 +186,12 @@ macro_rules! jk_primitive {
         impl TypeCheck for JkConstant<char> {
             fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from("char"))
+            }
+
+            fn set_cached_type(&mut self, _: CheckedType) {}
+
+            fn cached_type(&self) -> Option<&CheckedType> {
+                Some(&self.1)
             }
         }
 
@@ -221,9 +245,21 @@ macro_rules! jk_primitive {
             fn resolve_type(&self, _: &mut TypeCtx) -> CheckedType {
                 CheckedType::Resolved(TypeId::from($s))
             }
+
+            fn set_cached_type(&mut self, _: CheckedType) {}
+
+            fn cached_type(&self) -> Option<&CheckedType> {
+                Some(&self.1)
+            }
         }
 
         impl Generic for JkConstant<$t> {}
+
+        impl From<$t> for JkConstant<$t> {
+            fn from(rust_value: $t) -> Self {
+                JkConstant(rust_value, CheckedType::Resolved(TypeId::from("$s")))
+            }
+        }
     };
 }
 
@@ -305,19 +341,25 @@ impl TypeCheck for JkString {
     fn resolve_type(&self, _ctx: &mut TypeCtx) -> CheckedType {
         CheckedType::Resolved(TypeId::from("string"))
     }
+
+    fn set_cached_type(&mut self, _: CheckedType) {}
+
+    fn cached_type(&self) -> Option<&CheckedType> {
+        Some(&self.1)
+    }
 }
 
 impl Generic for JkString {}
 
 impl From<&str> for JkConstant<String> {
     fn from(s: &str) -> Self {
-        JkConstant(s.to_string())
+        JkConstant(s.to_string(), CheckedType::Resolved(TypeId::from("string")))
     }
 }
 
-impl<T: Clone> From<T> for JkConstant<T> {
-    fn from(rust_value: T) -> Self {
-        JkConstant(rust_value)
+impl From<String> for JkConstant<String> {
+    fn from(s: String) -> Self {
+        JkConstant(s, CheckedType::Resolved(TypeId::from("string")))
     }
 }
 


### PR DESCRIPTION
To allow later passes to access the type of an instruction without needing to perform the typechecking again, cache the type of each instruction *in* the instruction. This PR adds *a lot* of mutability which I am not happy with, but makes genericity possible. I have no idea how to do this without mutability or the repetition of a typechecking pass during the generic pass