### PR TITLE
Add `CheckedType::Later`

### DIFF
--- a/interpreter/jinko.rs
+++ b/interpreter/jinko.rs
@@ -42,7 +42,7 @@ fn handle_exit_code(result: Option<ObjectInstance>) -> ! {
                 _ => exit(0),
             },
             CheckedType::Void => exit(0),
-            CheckedType::Unknown => unreachable!("this shouldn't happen"),
+            CheckedType::Later | CheckedType::Error => unreachable!("this shouldn't happen"),
         },
     }
 }

--- a/src/instance/mod.rs
+++ b/src/instance/mod.rs
@@ -44,7 +44,7 @@ pub struct ObjectInstance {
 impl ObjectInstance {
     /// Create a new, empty instance without a type or a size
     pub fn empty() -> ObjectInstance {
-        ObjectInstance::new(CheckedType::Unknown, 0, vec![], None)
+        ObjectInstance::new(CheckedType::Error, 0, vec![], None)
     }
 
     /// Create a new instance

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -137,7 +137,7 @@ impl TypeCheck for BinaryOp {
                 self.op.as_str(),
                 r_type,
             )));
-            return CheckedType::Unknown;
+            return CheckedType::Error;
         }
 
         match self.op {

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -80,7 +80,7 @@ impl TypeCheck for FieldAccess {
                     "trying to access field `{}` on statement",
                     self.field_name
                 )));
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         };
 
@@ -98,7 +98,7 @@ impl TypeCheck for FieldAccess {
                     "trying to access field `{}` on instance of type `{}`",
                     self.field_name, instance_ty
                 )));
-                CheckedType::Unknown
+                CheckedType::Error
             }
         }
     }

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -217,7 +217,7 @@ impl TypeCheck for FunctionCall {
                     "function `{}` was not declared in this scope",
                     self.name()
                 )));
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         };
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -256,7 +256,7 @@ impl TypeCheck for FunctionDec {
 
                 ctx.scope_exit();
 
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         }
 

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -108,7 +108,7 @@ impl TypeCheck for IfElse {
                         "incompatible types for `if` and `else` block: {} and {}",
                         if_ty, else_ty,
                     )));
-                    CheckedType::Unknown
+                    CheckedType::Error
                 } else {
                     if_ty
                 }
@@ -118,7 +118,7 @@ impl TypeCheck for IfElse {
                     "`if` block has a return type ({}) but no else block to match it",
                     if_ty
                 )));
-                CheckedType::Unknown
+                CheckedType::Error
             }
         }
     }

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -247,7 +247,7 @@ impl TypeCheck for Incl {
             Ok(f) => f,
             Err(e) => {
                 ctx.error(e);
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         };
 
@@ -262,7 +262,7 @@ impl TypeCheck for Incl {
             Err((e1, e2)) => {
                 ctx.error(e1);
                 ctx.error(e2);
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         };
 

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -162,7 +162,7 @@ impl TypeCheck for TypeInstantiation {
                     // FIXME: Remove this clone, not useful
                     CheckedType::Resolved(self.type_name.clone())
                 )));
-                return CheckedType::Unknown;
+                return CheckedType::Error;
             }
         };
 

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -100,7 +100,7 @@ impl TypeCheck for Var {
                     Error::new(ErrKind::TypeChecker)
                         .with_msg(format!("use of undeclared variable: `{}`", self.name())),
                 );
-                CheckedType::Unknown
+                CheckedType::Error
             }
         }
     }

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -121,7 +121,7 @@ impl TypeCheck for VarAssign {
                         self.symbol()
                     );
                     ctx.error(Error::new(ErrKind::TypeChecker).with_msg(err_msg));
-                    return CheckedType::Unknown;
+                    return CheckedType::Error;
                 }
 
                 checked_ty.clone()
@@ -146,7 +146,7 @@ impl TypeCheck for VarAssign {
                 self.value().print(),
                 self.symbol
             )));
-            return CheckedType::Unknown;
+            return CheckedType::Error;
         }
 
         if var_ty != value_ty {
@@ -154,7 +154,7 @@ impl TypeCheck for VarAssign {
                 "trying to assign value of types `{}` to variable of type `{}`",
                 value_ty, var_ty
             )));
-            return CheckedType::Unknown;
+            return CheckedType::Error;
         }
 
         CheckedType::Void

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -76,7 +76,7 @@ impl TypeCheck for VarOrEmptyType {
         };
 
         match kind {
-            Kind::Unknown => CheckedType::Unknown,
+            Kind::Unknown => CheckedType::Error,
             Kind::EmptyTypeInst => CheckedType::Resolved(TypeId::new(self.symbol.clone())),
             Kind::VarAccess => ctx.get_var(&self.symbol).unwrap().to_owned(),
         }
@@ -86,7 +86,8 @@ impl TypeCheck for VarOrEmptyType {
         match ty {
             CheckedType::Void => self.kind = Kind::VarAccess,
             CheckedType::Resolved(_) => self.kind = Kind::EmptyTypeInst,
-            CheckedType::Unknown => self.kind = Kind::Unknown,
+            // FIXME: Is Later truly an error here?
+            CheckedType::Later | CheckedType::Error => self.kind = Kind::Unknown,
         }
         self.cached_type = Some(ty);
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -17,12 +17,13 @@ use std::{
 pub enum CheckedType {
     Resolved(TypeId),
     Void,
-    Unknown,
+    Later,
+    Error,
 }
 
 impl Default for CheckedType {
     fn default() -> CheckedType {
-        CheckedType::Unknown
+        CheckedType::Error
     }
 }
 
@@ -31,7 +32,7 @@ impl Display for CheckedType {
         match self {
             CheckedType::Resolved(ty) => write!(f, "{}", ty),
             CheckedType::Void => write!(f, "{}", "void".purple()),
-            CheckedType::Unknown => write!(f, "{}", "!!unknown!!".red()),
+            CheckedType::Later | CheckedType::Error => write!(f, "{}", "!!unknown!!".red()),
         }
     }
 }
@@ -217,8 +218,12 @@ impl Default for TypeCtx {
 ///     - Resolve(type): This means that the type of the [`Instruction`] was abled to
 ///     get resolved statically
 ///     - Void: The [`Instruction`] is not of any type. It corresponds to a statement.
-///     - Unknown: This means that even after the typechecking pass, the instruction's
-///     type is still unclear.
+///     - Later: The [`Instruction`] cannot be typechecked at the time. This can happen
+///       due to a function/type declaration being past the call/instantiation site, or in
+///       the case of generics when monomorphized functions might not have been generated
+///       yet.
+///     - Error: This means that even after the typechecking pass, the instruction's
+///       type is still unclear.
 /// Every [`Instruction`] should keep a cached copy of its own type. This is important
 /// for later passes of the typechecker or generic expansion. To do so, a special field
 /// of the type `Option<CheckedType>` should be kept, and originally initialized to `None`


### PR DESCRIPTION
This PR adds a new variant to the `CheckedType` enum. Its usage is described in the documentation of the `resolve_type()` trait function