### PR TITLE
Do not declare generic functions twice

### DIFF
--- a/tests/ft/generics/generics.yml
+++ b/tests/ft/generics/generics.yml
@@ -24,3 +24,8 @@ tests:
     args:
       - "tests/ft/generics/undeclared_arg_generic.jk"
     exit_code: 1
+  - name: "Valid call to same generic fn twice"
+    binary: "target/debug/jinko"
+    args:
+      - "tests/ft/generics/valid_call_generic_twice.jk"
+    exit_code: 0

--- a/tests/ft/generics/valid_call_generic_twice.jk
+++ b/tests/ft/generics/valid_call_generic_twice.jk
@@ -1,0 +1,4 @@
+incl generic_fns
+
+id[bool](false);
+id[bool](true);


### PR DESCRIPTION
- generics: WIP allow calling and declaring generic functions
- generics: Remove `generate_new()` trait function
- generics: Add functional test directory
- generics: Return CheckedType::Later in generic funcdec
- generics: Add test for calling the same generic twice
- function_call: Do not recreate generic if it is already present
