### PR TITLE
Cleanup generic implementation

### DIFF
--- a/interpreter/jinko.rs
+++ b/interpreter/jinko.rs
@@ -42,7 +42,7 @@ fn handle_exit_code(result: Option<ObjectInstance>) -> ! {
                 _ => exit(0),
             },
             CheckedType::Void => exit(0),
-            CheckedType::Later | CheckedType::Error => unreachable!("this shouldn't happen"),
+            CheckedType::Error | CheckedType::Later => unreachable!("this shouldn't happen"),
         },
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -307,7 +307,7 @@ impl Context {
         let new_nodes = self.typechecker.take_specialized_nodes();
         new_nodes.into_iter().for_each(|node| {
             if let Err(e) = match node {
-                SpecializedNode::Func(f) => self.add_function(f),
+                SpecializedNode::Func(f) => self.add_function(*f),
                 SpecializedNode::Type(t) => self.add_type(t),
             } {
                 self.error(e);

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use crate::error::{ErrKind, Error, ErrorHandler};
 use crate::instruction::{Block, FunctionDec, FunctionKind, Instruction, TypeDec, Var};
 use crate::parser;
-use crate::typechecker::{TypeCheck, TypeCtx, TypeId};
+use crate::typechecker::{SpecializedNode, TypeCheck, TypeCtx, TypeId};
 use crate::ObjectInstance;
 use crate::{Builtins, CheckedType, Generic};
 
@@ -301,15 +301,24 @@ impl Context {
         let mut is_err = false;
 
         ep.type_of(&mut self.typechecker);
-        if ep.expand(self).is_err() {
-            is_err = true;
-        }
-
-        ep.resolve_self(&mut self.typechecker);
+        // if ep.expand(self).is_err() {
+        //     is_err = true;
+        // }
+        // ep.resolve_self(&mut self.typechecker);
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);
         self.emit_errors();
+
+        let new_nodes = self.typechecker.take_specialized_nodes();
+        new_nodes.into_iter().for_each(|node| {
+            if let Err(e) = match node {
+                SpecializedNode::Func(f) => self.add_function(f),
+                SpecializedNode::Type(t) => self.add_type(t),
+            } {
+                self.error(e);
+            }
+        });
 
         match self.error_handler.has_errors() || is_err {
             true => Err(Error::new(ErrKind::Context)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -298,17 +298,20 @@ impl Context {
     fn inner_check(&mut self, ep: &mut Block) -> Result<(), Error> {
         self.scope_enter();
 
+        let mut is_err = false;
+
         ep.type_of(&mut self.typechecker);
-        ep.expand(self);
+        if ep.expand(self).is_err() {
+            is_err = true;
+        }
+
         ep.resolve_self(&mut self.typechecker);
-        self.typechecker.start_second_pass();
-        ep.type_of(&mut self.typechecker);
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);
         self.emit_errors();
 
-        match self.error_handler.has_errors() {
+        match self.error_handler.has_errors() || is_err {
             true => Err(Error::new(ErrKind::Context)),
             false => Ok(()),
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,7 +20,7 @@ use crate::instruction::{Block, FunctionDec, FunctionKind, Instruction, TypeDec,
 use crate::parser;
 use crate::typechecker::{SpecializedNode, TypeCheck, TypeCtx, TypeId};
 use crate::ObjectInstance;
-use crate::{Builtins, CheckedType, Generic};
+use crate::{Builtins, CheckedType};
 
 /// Type the context uses for keys
 type CtxKey = String;
@@ -298,13 +298,7 @@ impl Context {
     fn inner_check(&mut self, ep: &mut Block) -> Result<(), Error> {
         self.scope_enter();
 
-        let mut is_err = false;
-
         ep.type_of(&mut self.typechecker);
-        // if ep.expand(self).is_err() {
-        //     is_err = true;
-        // }
-        // ep.resolve_self(&mut self.typechecker);
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);
@@ -320,7 +314,7 @@ impl Context {
             }
         });
 
-        match self.error_handler.has_errors() || is_err {
+        match self.error_handler.has_errors() {
             true => Err(Error::new(ErrKind::Context)),
             false => Ok(()),
         }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -88,12 +88,14 @@ pub trait Generic {
     /// Expand all generics contained in the current instruction, or its sub-instructions.
     /// For example, a [`Block`] is responsible for expanding the generics of all the
     /// functions defined within itself.
-    fn expand(&self, _ctx: &mut Context) {}
+    fn expand(&self, _ctx: &mut Context) -> Result<(), Error> {
+        Ok(())
+    }
 
     /// Mutate an instruction in order to resolve to the proper, expanded generic instruction.
     /// For example, a call to the function `f[T]` should now be replaced by a call to
     /// the function `generics::mangle("f", GenericMap { TypeId "T" })` // FIXME: Fix doc
-    fn resolve_self(&mut self, _ctx: &mut TypeCtx) {}
+    fn resolve_self(&mut self, _ctx: &mut Context) {}
 }
 
 #[cfg(test)]

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -24,6 +24,16 @@ impl GenericMap {
         if generics.len() != resolved.len() {
             // FIXME: Add better error message here printing both sets of generics
             let err_msg = String::from("missing types in generic expansion");
+            let mut err_msg = format!("{}\ngeneric types: ", err_msg);
+            for generic in generics {
+                err_msg.push_str(&format!("{}", generic));
+            }
+
+            let mut err_msg = format!("{}\nresolved types: ", err_msg);
+            for resolved in resolved {
+                err_msg.push_str(&format!("{}", resolved));
+            }
+
             return Err(Error::new(ErrKind::Generics).with_msg(err_msg));
         }
 
@@ -95,7 +105,7 @@ pub trait Generic {
     /// Mutate an instruction in order to resolve to the proper, expanded generic instruction.
     /// For example, a call to the function `f[T]` should now be replaced by a call to
     /// the function `generics::mangle("f", GenericMap { TypeId "T" })` // FIXME: Fix doc
-    fn resolve_self(&mut self, _ctx: &mut Context) {}
+    fn resolve_self(&mut self, _ctx: &mut TypeCtx) {}
 }
 
 #[cfg(test)]

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -89,8 +89,7 @@ impl TypeCheck for FieldAccess {
         let instance_ty = self.instance.type_of(ctx);
         let instance_ty_name = match &instance_ty {
             CheckedType::Resolved(ti) => ti.id(),
-            CheckedType::Later => return CheckedType::Later,
-            _ => {
+            CheckedType::Void => {
                 ctx.error(
                     Error::new(ErrKind::TypeChecker)
                         .with_msg(format!(
@@ -101,6 +100,7 @@ impl TypeCheck for FieldAccess {
                 );
                 return CheckedType::Error;
             }
+            _ => return CheckedType::Error,
         };
 
         // We can unwrap here since the type that was resolved from the instance HAS
@@ -136,7 +136,7 @@ impl TypeCheck for FieldAccess {
 }
 
 impl Generic for FieldAccess {
-    fn expand(&self, ctx: &mut Context) {
+    fn expand(&self, ctx: &mut Context) -> Result<(), Error> {
         self.instance.expand(ctx)
     }
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -305,9 +305,11 @@ impl TypeCheck for FunctionCall {
         let args_type = args_type.clone();
 
         if !function.generics().is_empty() || !self.generics.is_empty() {
+            log!("resolving generic call");
             return self.resolve_generic_call(function, ctx);
         }
 
+        log!("resolving args");
         let mut errors = vec![];
         let mut args = vec![];
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -207,7 +207,7 @@ impl FunctionCall {
                     }
                 };
 
-            ctx.add_specialized_node(SpecializedNode::Func(specialized_fn));
+            ctx.add_specialized_node(SpecializedNode::Func(Box::new(specialized_fn)));
         }
 
         self.fn_name = specialized_name;

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -346,12 +346,6 @@ impl TypeCheck for FunctionDec {
         if let Some(b) = &mut self.block {
             let block_ty = b.type_of(ctx);
 
-            // If the block's type cannot be determined yet, this is not an
-            // error: We simply have to wait for the next typechecking pass
-            if block_ty == CheckedType::Later {
-                return CheckedType::Later;
-            }
-
             if block_ty != return_ty {
                 ctx.error(
                     Error::new(ErrKind::TypeChecker)

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -56,7 +56,7 @@ impl FunctionDec {
         &self,
         mangled_name: String,
         type_map: &GenericMap,
-        ctx: &mut Context,
+        ctx: &mut TypeCtx,
     ) -> Result<FunctionDec, Error> {
         let mut new_fn = self.clone();
         new_fn.name = mangled_name;

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -43,19 +43,9 @@ impl Instruction for MethodCall {
     fn execute(&self, ctx: &mut Context) -> Option<ObjectInstance> {
         log!("method call enter: {}", &self.print());
 
-        // FIXME: No clone here
-        let mut call = self.method.clone();
-        if let Some(loc) = &self.location {
-            call.set_location(loc.clone())
-        };
-
-        call.add_arg_front(self.var.clone());
-
-        log!("desugaring to: {}", &call.print());
-
         log!("method call exit: {}", &self.print());
 
-        call.execute(ctx)
+        self.method.execute(ctx)
     }
 
     fn location(&self) -> Option<&SpanTuple> {

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -4,7 +4,7 @@
 use crate::generics::{self, Generic};
 use crate::instruction::FunctionCall;
 use crate::typechecker::{CheckedType, TypeCtx};
-use crate::{log, Context, InstrKind, Instruction, ObjectInstance, SpanTuple, TypeCheck};
+use crate::{log, Context, Error, InstrKind, Instruction, ObjectInstance, SpanTuple, TypeCheck};
 
 #[derive(Clone)]
 pub struct MethodCall {
@@ -84,7 +84,7 @@ impl TypeCheck for MethodCall {
 }
 
 impl Generic for MethodCall {
-    fn expand(&self, ctx: &mut Context) {
+    fn expand(&self, ctx: &mut Context) -> Result<(), Error> {
         let mut call = self.method.clone();
         call.add_arg_front(self.var.clone());
         if let Some(loc) = &self.location {

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -65,13 +65,13 @@ impl Instruction for MethodCall {
 
 impl TypeCheck for MethodCall {
     fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
-        let mut call = self.method.clone();
-        call.add_arg_front(self.var.clone());
+        log!("typechecking method {}", self.method.name());
+        self.method.add_arg_front(self.var.clone());
         if let Some(loc) = &self.location {
-            call.set_location(loc.clone())
+            self.method.set_location(loc.clone())
         };
 
-        call.type_of(ctx)
+        self.method.type_of(ctx)
     }
 
     fn set_cached_type(&mut self, ty: CheckedType) {

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -120,16 +120,18 @@ mod tests {
     #[test]
     fn t_execute() {
         let mut ctx = Context::new();
-        let func_dec = constructs::expr(span!("func __first(a: int, b: int) -> int { a }"))
+        let mut func_dec = constructs::expr(span!("func __first(a: int, b: int) -> int { a }"))
             .unwrap()
             .1;
+        ctx.type_check(&mut *func_dec).unwrap();
         func_dec.execute(&mut ctx);
 
         let var1 = Box::new(JkInt::from(1));
         let var2 = Box::new(JkInt::from(2));
         let method = FunctionCall::new("__first".to_owned(), vec![], vec![var2]);
 
-        let mc = MethodCall::new(var1, method);
+        let mut mc = MethodCall::new(var1, method);
+        ctx.type_check(&mut mc).unwrap();
 
         assert_eq!(mc.execute(&mut ctx).unwrap(), JkInt::from(1).to_instance());
     }

--- a/src/instruction/mod.rs
+++ b/src/instruction/mod.rs
@@ -2,6 +2,8 @@
 //! When using nested instructions, such as `foo = bar();`, you're actually using
 //! two instructions: A function call expression, and a variable assignment statement
 
+use std::fmt::Debug;
+
 use crate::{Context, ErrKind, Error, Generic, ObjectInstance, SpanTuple, TypeCheck};
 
 use colored::Colorize;
@@ -126,6 +128,12 @@ pub trait Instruction: InstructionClone + Downcast + TypeCheck + Generic {
 }
 
 impl_downcast!(Instruction);
+
+impl Debug for dyn Instruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.print())
+    }
+}
 
 /// The `InstructionClone` provides a wrapper around `Instruction` to allow cloning them
 pub trait InstructionClone {

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -119,21 +119,19 @@ impl Instruction for VarAssign {
 
 impl TypeCheck for VarAssign {
     fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
-        let second_pass = ctx.is_second_pass();
         let var_ty = match ctx.get_var(&self.symbol) {
             // FIXME: Remove clone?
             Some(checked_ty) => {
                 // If `self` is mutable, then it means that we are creating the variable
                 // for the first time. However, we entered the match arm because the variable
                 // is already present in the context. Error out appropriately.
-                // In the second pass of the typechecker however, this is an appropriate
-                // behavior... Which is a bit annoying to handle.
-                // TODO: Think about removing the call to `is_second_pass()`
-                if self.mutable() && !second_pass {
+                if self.mutable() {
                     let err_msg = format!(
                         "trying to redefine already defined variable: {}",
                         self.symbol()
                     );
+
+                    // FIXME: Add hint here about previous definition
                     ctx.error(
                         Error::new(ErrKind::TypeChecker)
                             .with_msg(err_msg)
@@ -199,7 +197,7 @@ impl TypeCheck for VarAssign {
 }
 
 impl Generic for VarAssign {
-    fn expand(&self, ctx: &mut Context) {
+    fn expand(&self, ctx: &mut Context) -> Result<(), Error> {
         self.value.expand(ctx)
     }
 

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -100,8 +100,7 @@ impl TypeCheck for VarOrEmptyType {
         match ty {
             CheckedType::Void => self.kind = Kind::VarAccess,
             CheckedType::Resolved(_) => self.kind = Kind::EmptyTypeInst,
-            // FIXME: Is Later truly an error here?
-            CheckedType::Later | CheckedType::Error => self.kind = Kind::Unknown,
+            CheckedType::Error | CheckedType::Later => self.kind = Kind::Unknown,
         }
         self.cached_type = Some(ty);
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -19,9 +19,10 @@ use std::{
 #[derive(Clone, PartialEq, Debug)]
 pub enum CheckedType {
     Resolved(TypeId),
+    // Should we remove this for Resolved(TypeId::void())?
     Void,
-    Later,
     Error,
+    Later,
 }
 
 impl Default for CheckedType {
@@ -35,8 +36,9 @@ impl Display for CheckedType {
         match self {
             CheckedType::Resolved(ty) => write!(f, "{}", ty),
             CheckedType::Void => write!(f, "{}", "void".purple()),
-            CheckedType::Later => write!(f, "{}", "!!unresolved yet!!".yellow()),
             CheckedType::Error => write!(f, "{}", "!!unknown!!".red()),
+            // This should never happen
+            CheckedType::Later => write!(f, "{}", "!!unresolved!!".red().underline()),
         }
     }
 }
@@ -61,13 +63,6 @@ pub struct TypeCtx {
     /// For functions, we keep a vector of argument types as well as the return type.
     /// Custom types need to keep a type for themselves, as well as types for all their fields
     types: ScopeMap<CheckedType, FunctionDec, CustomTypeType>,
-    /// Is the type context executing its second pass or not. The second pass of the typechecking
-    /// process is to resolve generic calls and make sure that the functions called on the
-    /// expanded types are actually present. Plus, this also allows us to call/instantiate
-    /// functions/types defined after the call/instantiation.
-    /// At this stage, we do not emit "already defined" errors, as they will all have been
-    /// emitted by the first pass already.
-    is_second_pass: bool,
     // FIXME: Remove both of these fields...
     /// Path from which the typechecking context was instantiated
     path: Option<PathBuf>,
@@ -81,7 +76,6 @@ impl TypeCtx {
         let mut ctx = TypeCtx {
             error_handler: ErrorHandler::default(),
             types: ScopeMap::new(),
-            is_second_pass: false,
             path: None,
             included: HashSet::new(),
         };
@@ -106,14 +100,6 @@ impl TypeCtx {
         declare_primitive!(string);
 
         ctx
-    }
-
-    pub fn start_second_pass(&mut self) {
-        self.is_second_pass = true
-    }
-
-    pub fn is_second_pass(&self) -> bool {
-        self.is_second_pass
     }
 
     // FIXME: Remove these three functions
@@ -145,22 +131,24 @@ impl TypeCtx {
 
     /// Declare a newly-created variable's type
     pub fn declare_var(&mut self, name: String, ty: CheckedType) -> Result<(), Error> {
-        self.types
-            .add_variable(name, ty)
-            .or_else(|e| if self.is_second_pass { Ok(()) } else { Err(e) })
+        // FIXME: Add hint here too
+        self.types.add_variable(name, ty)
     }
 
     /// Declare a newly-created function's type
     pub fn declare_function(&mut self, name: String, function: FunctionDec) -> Result<(), Error> {
-        let loc = function.loc();
-        self.types.add_function(name, function).or_else(|e| {
-            if self.is_second_pass {
-                Ok(())
-            } else {
-                // FIXME: Add hint here about previous declaration
-                Err(e.with_loc(loc))
+        // FIXME: Remove clone here
+        match self.types.add_function(name.clone(), function) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                let previous_dec = self.types.get_function(&name).unwrap();
+                Err(err.with_hint(
+                    Error::new(crate::ErrKind::Hint)
+                        .with_msg(String::from("previous declaration here"))
+                        .with_loc(previous_dec.loc()),
+                ))
             }
-        })
+        }
     }
 
     /// Declare a newly-created custom type
@@ -172,7 +160,7 @@ impl TypeCtx {
     ) -> Result<(), Error> {
         self.types
             .add_type(name, CustomTypeType { self_ty, fields_ty })
-            .or_else(|e| if self.is_second_pass { Ok(()) } else { Err(e) })
+        // FIXME: Add hint here too
     }
 
     /// Access a previously declared variable's type
@@ -248,11 +236,8 @@ pub trait TypeCheck {
                     self.set_cached_type(CheckedType::Void);
                     CheckedType::Void
                 }
-                CheckedType::Later => match ctx.is_second_pass() {
-                    false => CheckedType::Later,
-                    true => CheckedType::Error,
-                },
                 CheckedType::Error => CheckedType::Error,
+                CheckedType::Later => CheckedType::Later,
             },
             Some(ty) => ty.clone(),
         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -168,15 +168,11 @@ impl TypeCtx {
     }
 
     /// Add a new generated node to the context
-    pub fn add_specialized_node(&mut self, node: SpecializedNode) {
-        if let Err(e) = match &node {
-            SpecializedNode::Func(f) => self.declare_function(f.name().to_owned(), f.clone()),
-            SpecializedNode::Type(_t) => {
-                todo!()
-            }
-        } {
-            self.error(e);
-        }
+    pub fn add_specialized_node(&mut self, mut node: SpecializedNode) {
+        match &mut node {
+            SpecializedNode::Func(f) => f.type_of(self),
+            SpecializedNode::Type(t) => t.type_of(self),
+        };
 
         self.generated.push(node)
     }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -55,7 +55,7 @@ struct CustomTypeType {
 /// Possible generic generated nodes. Since we can only expand generic functions or
 /// generic types, there is no need to store any other instruction type.
 pub enum SpecializedNode {
-    Func(FunctionDec),
+    Func(Box<FunctionDec>),
     Type(TypeDec),
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -8,7 +8,7 @@ pub use type_id::{TypeId, PRIMITIVE_TYPES};
 use crate::{
     error::ErrorHandler,
     instruction::{FunctionDec, TypeDec},
-    log, Error, ScopeMap,
+    Error, ScopeMap,
 };
 use colored::Colorize;
 use std::{
@@ -171,7 +171,7 @@ impl TypeCtx {
     pub fn add_specialized_node(&mut self, node: SpecializedNode) {
         if let Err(e) = match &node {
             SpecializedNode::Func(f) => self.declare_function(f.name().to_owned(), f.clone()),
-            SpecializedNode::Type(t) => {
+            SpecializedNode::Type(_t) => {
                 todo!()
             }
         } {

--- a/tests/ft/generics/valid_multiple_ducktyping.jk
+++ b/tests/ft/generics/valid_multiple_ducktyping.jk
@@ -2,27 +2,27 @@ incl generic_fns;
 
 type Griffin;
 
-func bark[Griffin](g: Griffin) {
+func bark(g: Griffin) {
 	println("bark!")
 }
 
-func eat[Griffin](g: Griffin) {
+func eat(g: Griffin) {
 	println("nom")
 }
 
-func scream[Griffin](g: Griffin) {
+func scream(g: Griffin) {
 	println("AAAAAAAH")
 }
 
-func run[Griffin](g: Griffin) {
+func run(g: Griffin) {
 	println("uf uf uf")
 }
 
-func swim[Griffin](g: Griffin) {
+func swim(g: Griffin) {
 	println("splish splosh")
 }
 
-func fly[Griffin](g: Griffin) {
+func fly(g: Griffin) {
 	println("wouuuuuuh")
 }
 

--- a/tests/func_tests.sh
+++ b/tests/func_tests.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-ft --version > /dev/null
-ft_exists=$?
+ftf --version > /dev/null
+ftf_exists=$?
 
-if [ $ft_exists -ne 0 ]
+if [ $ftf_exists -ne 0 ]
 then
-    printf '\n`ft` not found. Install it using the following command\n\n'
-    printf '\tcargo install --git https://github.com/cohenarthur/ft\n\n'
+    printf '\n`ftf` not found. Install it using the following command\n\n'
+    printf '\tcargo install ftf\n\n'
 
     exit 1
 fi
@@ -21,12 +21,12 @@ then
     printf "Test files:\n$@\n\n"
 
     for file in $@; do
-        ft -f $file
+        ftf -f $file
     done
 else
     files=$(find tests -name "*.yml")
 
     printf "Test files:\n$files\n\n"
 
-    ft -f $files
+    ftf -f $files
 fi


### PR DESCRIPTION
This PR cleans up the generic implementation to add new nodes to the outermost scope, in order to make them available even after type checking