### PR TITLE
Do proper aggregation sites and emission sites when emitting errors

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use crate::context::Context;
 #[cfg(feature = "ffi")]
 use crate::ffi;
-use crate::generics;
 use crate::instance::{FromObjectInstance, ObjectInstance, ToObjectInstance};
 use crate::instruction::Instruction;
 use crate::value::{JkBool, JkChar, JkFloat, JkInt, JkString};
@@ -189,13 +188,14 @@ impl Builtins {
     pub fn contains(&self, name: &str) -> bool {
         // We can demangle builtins to dispatch to our single, non generic
         // implementation.
-        let name = generics::original_name(name);
+        // let name = generics::original_name(name);
 
         self.functions.contains_key(name)
     }
 
     pub fn get(&self, builtin: &str) -> Option<&BuiltinFn> {
-        self.functions.get(generics::original_name(builtin))
+        // self.functions.get(generics::original_name(builtin))
+        self.functions.get(builtin)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -278,8 +278,7 @@ impl Context {
     fn inner_check(&mut self, ep: &mut Block) -> Result<(), Error> {
         self.scope_enter();
 
-        log!("starting first pass of typechecking");
-        ep.type_of(&mut self.typechecker);
+        ep.type_of(&mut self.typechecker)?;
 
         self.error_handler
             .append(&mut self.typechecker.error_handler);

--- a/src/context.rs
+++ b/src/context.rs
@@ -271,13 +271,14 @@ impl Context {
 
         match self.error_handler.has_errors() {
             true => Err(Error::new(ErrKind::TypeChecker)),
-            false => Ok(res),
+            false => Ok(res?),
         }
     }
 
     fn inner_check(&mut self, ep: &mut Block) -> Result<(), Error> {
         self.scope_enter();
 
+        log!("starting first pass of typechecking");
         ep.type_of(&mut self.typechecker);
 
         self.error_handler

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -6,7 +6,6 @@ use std::fmt::Debug;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::GenericUser;
 use crate::instance::ObjectInstance;
 use crate::location::SpanTuple;
 use crate::typechecker::TypeCheck;
@@ -68,7 +67,7 @@ pub enum InstrKind {
 
 /// The `Instruction` trait is the basic trait for all of Jinko's execution nodes. Each
 /// node that can be executed needs to implement it
-pub trait Instruction: InstructionClone + Downcast + TypeCheck + GenericUser {
+pub trait Instruction: InstructionClone + Downcast + TypeCheck {
     // FIXME: Add Rename here
     /// Execute the instruction, altering the state of the context. Executing
     /// this method may return an object instance

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -7,7 +7,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::GenericUser;
 use crate::instance::{FromObjectInstance, ObjectInstance};
 use crate::instruction::{InstrKind, Instruction, Operator};
 use crate::location::SpanTuple;
@@ -169,13 +168,6 @@ impl TypeCheck for BinaryOp {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for BinaryOp {
-    fn resolve_usages(&mut self, type_map: &crate::generics::GenericMap, ctx: &mut TypeCtx) {
-        self.lhs.resolve_usages(type_map, ctx);
-        self.rhs.resolve_usages(type_map, ctx);
     }
 }
 

--- a/src/instruction/binary_op.rs
+++ b/src/instruction/binary_op.rs
@@ -134,32 +134,32 @@ impl Instruction for BinaryOp {
 }
 
 impl TypeCheck for BinaryOp {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let l_type = self.lhs.type_of(ctx);
-        let r_type = self.rhs.type_of(ctx);
+        let r_type = self.rhs.type_of(ctx)?;
+
+        // Unpacking after checking rhs to give maximum feedback to the user
+        let l_type = l_type?;
 
         if l_type != r_type {
-            ctx.error(
-                Error::new(ErrKind::TypeChecker)
-                    .with_msg(format!(
-                        "trying to do binary operation on invalid types: {} {} {}",
-                        l_type,
-                        self.op.as_str(),
-                        r_type,
-                    ))
-                    .with_loc(self.location.clone()),
-            );
-            return CheckedType::Error;
-        }
-
-        match self.op {
-            Operator::Lt
-            | Operator::Gt
-            | Operator::LtEq
-            | Operator::GtEq
-            | Operator::Equals
-            | Operator::NotEquals => CheckedType::Resolved(TypeId::from("bool")),
-            _ => l_type,
+            Err(Error::new(ErrKind::TypeChecker)
+                .with_msg(format!(
+                    "trying to do binary operation on invalid types: {} {} {}",
+                    l_type,
+                    self.op.as_str(),
+                    r_type,
+                ))
+                .with_loc(self.location.clone()))
+        } else {
+            match self.op {
+                Operator::Lt
+                | Operator::Gt
+                | Operator::LtEq
+                | Operator::GtEq
+                | Operator::Equals
+                | Operator::NotEquals => Ok(CheckedType::Resolved(TypeId::from("bool"))),
+                _ => Ok(l_type),
+            }
         }
     }
 

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -130,17 +130,24 @@ impl Instruction for Block {
 }
 
 impl TypeCheck for Block {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let last_type = self
             .instructions
             .iter_mut()
-            .map(|inst| inst.type_of(ctx))
+            .map(|inst| match inst.type_of(ctx) {
+                // Aggregate
+                Err(e) => {
+                    ctx.error(e);
+                    CheckedType::Error
+                }
+                Ok(t) => t,
+            })
             .last()
             .unwrap_or(CheckedType::Void);
 
         match &self.is_statement {
-            true => CheckedType::Void,
-            false => last_type,
+            true => Ok(CheckedType::Void),
+            false => Ok(last_type),
         }
     }
 

--- a/src/instruction/block.rs
+++ b/src/instruction/block.rs
@@ -18,7 +18,7 @@
 //! Otherwise, it's `void`
 
 use crate::context::Context;
-use crate::generics::{GenericMap, GenericUser};
+use crate::error::Error;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -157,14 +157,6 @@ impl TypeCheck for Block {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for Block {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        self.instructions
-            .iter_mut()
-            .for_each(|inst| inst.resolve_usages(type_map, ctx))
     }
 }
 

--- a/src/instruction/dec_arg.rs
+++ b/src/instruction/dec_arg.rs
@@ -1,8 +1,7 @@
 use std::fmt::{Display, Formatter, Result};
 
-use crate::generics::{GenericMap, GenericUser};
 use crate::location::SpanTuple;
-use crate::typechecker::{TypeCtx, TypeId};
+use crate::typechecker::TypeId;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DecArg {
@@ -44,12 +43,6 @@ impl DecArg {
     /// Set the location of the argument
     pub fn set_location(&mut self, location: SpanTuple) {
         self.location = Some(location)
-    }
-}
-
-impl GenericUser for DecArg {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        self.ty.resolve_usages(type_map, ctx)
     }
 }
 

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -3,7 +3,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{GenericMap, GenericUser};
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -123,12 +122,6 @@ impl TypeCheck for FieldAccess {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for FieldAccess {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        self.instance.resolve_usages(type_map, ctx)
     }
 }
 

--- a/src/instruction/field_access.rs
+++ b/src/instruction/field_access.rs
@@ -81,22 +81,21 @@ impl Instruction for FieldAccess {
 }
 
 impl TypeCheck for FieldAccess {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
-        let instance_ty = self.instance.type_of(ctx);
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        let instance_ty = self.instance.type_of(ctx)?;
         let instance_ty_name = match &instance_ty {
-            CheckedType::Resolved(ti) => ti.id(),
+            CheckedType::Resolved(ty) => ty.id(),
             CheckedType::Void => {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!(
-                            "trying to access field `{}` on statement",
-                            self.field_name
-                        ))
-                        .with_loc(self.instance.location().cloned()),
-                );
-                return CheckedType::Error;
+                return Err(Error::new(ErrKind::TypeChecker)
+                    .with_msg(format!(
+                        "trying to access field `{}` on statement",
+                        self.field_name
+                    ))
+                    .with_loc(self.instance.location().cloned()));
             }
-            _ => return CheckedType::Error,
+            // FIXME: Remove this once we don't have ::Later and ::Error variants
+            // anymore
+            _ => unreachable!(),
         };
 
         // We can unwrap here since the type that was resolved from the instance HAS
@@ -108,18 +107,13 @@ impl TypeCheck for FieldAccess {
             .iter()
             .find(|dec_arg| dec_arg.name() == self.field_name)
         {
-            Some(dec_arg) => CheckedType::Resolved(dec_arg.get_type().clone()),
-            None => {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!(
-                            "trying to access field `{}` on instance of type `{}`",
-                            self.field_name, instance_ty
-                        ))
-                        .with_loc(self.location.clone()),
-                );
-                CheckedType::Error
-            }
+            Some(dec_arg) => Ok(CheckedType::Resolved(dec_arg.get_type().clone())),
+            None => Err(Error::new(ErrKind::TypeChecker)
+                .with_msg(format!(
+                    "trying to access field `{}` on instance of type `{}`",
+                    self.field_name, instance_ty
+                ))
+                .with_loc(self.location.clone())),
         }
     }
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -6,12 +6,11 @@ use std::rc::Rc;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{self, GenericExpander, GenericMap, GenericUser};
 use crate::instance::ObjectInstance;
 use crate::instruction::{FunctionDec, FunctionKind, Var};
 use crate::instruction::{InstrKind, Instruction};
 use crate::location::SpanTuple;
-use crate::typechecker::{CheckedType, SpecializedNode, TypeCheck, TypeCtx, TypeId};
+use crate::typechecker::{CheckedType, TypeCheck, TypeCtx, TypeId};
 
 #[derive(Clone)]
 pub struct FunctionCall {
@@ -180,34 +179,6 @@ impl FunctionCall {
     pub fn set_name(&mut self, fn_name: String) {
         self.fn_name = fn_name
     }
-
-    fn resolve_generic_call(
-        &mut self,
-        function: FunctionDec,
-        ctx: &mut TypeCtx,
-    ) -> Result<CheckedType, Error> {
-        log!(
-            "creating specialized fn. function generics: {}, call generics {}",
-            function.generics().len(),
-            self.generics().len()
-        );
-        let type_map = GenericMap::create(function.generics(), self.generics(), ctx)?;
-        let specialized_name = generics::mangle(function.name(), self.generics());
-        if ctx.get_function(&specialized_name).is_none() {
-            // FIXME: Remove this clone once we have proper symbols
-            let specialized_fn =
-                function.from_type_map(specialized_name.clone(), &type_map, ctx)?;
-
-            ctx.add_specialized_node(SpecializedNode::Func(Box::new(specialized_fn)))?;
-        }
-
-        self.fn_name = specialized_name;
-        self.generics = vec![];
-
-        // Recursively resolve the type of self now that we changed the
-        // function to call
-        self.type_of(ctx)
-    }
 }
 
 impl Instruction for FunctionCall {
@@ -275,13 +246,7 @@ impl Instruction for FunctionCall {
 }
 
 impl TypeCheck for FunctionCall {
-    fn type_log(&self) -> String {
-        self.fn_name.to_string()
-    }
-
     fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
-        log!("typechecking call to {}", self.fn_name);
-
         // FIXME: Expand generic here instead of resolving later
         // if !self.generics.is_empty() && !ctx.is_second_pass() {
         //     return CheckedType::Later;
@@ -306,9 +271,9 @@ impl TypeCheck for FunctionCall {
         let (args_type, return_type) = (function.args(), function.ty());
         let args_type = args_type.clone();
 
-        if !function.generics().is_empty() || !self.generics.is_empty() {
-            return self.resolve_generic_call(function, ctx);
-        }
+        // if !function.generics().is_empty() || !self.generics.is_empty() {
+        //     return self.resolve_generic_call(function, ctx);
+        // }
 
         let mut errors = vec![];
         let mut args = vec![];
@@ -368,125 +333,6 @@ impl TypeCheck for FunctionCall {
 
     fn set_cached_type(&mut self, ty: CheckedType) {
         self.cached_type = Some(ty);
-    }
-}
-
-impl GenericUser for FunctionCall {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        // For function calls, we can just change our name to one resolved
-        // using the generic map. And obviously just visit all of our arguments
-
-        // FIXME: Can we unwrap here?
-        let dec = match ctx.get_function(&self.fn_name) {
-            Some(f) => f,
-            None => {
-                ctx.error(Error::new(ErrKind::Generics)
-                    .with_msg(format!("trying to access undeclared function in new specialized function: `{}`", self.fn_name))
-                    .with_loc(self.location.clone()));
-                return;
-            }
-        };
-        let new_types = match type_map.specialized_types(dec.generics()) {
-            Err(e) => {
-                ctx.error(e.with_loc(self.location().cloned()));
-                return;
-            }
-            Ok(new_t) => new_t,
-        };
-
-        if self.generics.is_empty() && dec.generics().is_empty() {
-            return Ok(());
-        }
-
-        if !self.generics.is_empty() && dec.generics().is_empty() {
-            // FIXME: Format generic list in error too
-            ctx.error(
-                Error::new(ErrKind::Generics)
-                    .with_msg(format!(
-                        "calling non-generic function with generic arguments: `{}`",
-                        self.name()
-                    ))
-                    .with_loc(self.location.clone()),
-            );
-            return Err(Error::new(ErrKind::Generics));
-        }
-
-        let _type_map =
-            match GenericMap::create(dec.generics(), &self.generics, &mut ctx.typechecker) {
-                Err(e) => {
-                    ctx.error(e);
-                    return Err(Error::new(ErrKind::Generics));
-                }
-                Ok(m) => m,
-            };
-
-        // FIXME: Remove entirely?
-        // let mut new_fn = match dec.from_type_map(generic_name, &type_map, ctx) {
-        //     Ok(f) => f,
-        //     Err(e) => {
-        //         ctx.error(e.clone());
-        //         return Err(e);
-        //     }
-        // };
-        //
-        // if let Err(e) = ctx.type_check(&mut new_fn) {
-        //     // FIXME: This should probably be a generic error instead
-        //     // FIXME: The name is also mangled and shouldn't be
-        //     ctx.error(e);
-        // } else {
-        //     ctx.add_function(new_fn).unwrap();
-        // }
-
-        Ok(())
-    }
-
-    fn resolve_self(&mut self, ctx: &mut TypeCtx) {
-        let generic_name = generics::mangle(&self.fn_name, &self.generics);
-        log!("resolving call from {} to {}", self.fn_name, &generic_name);
-
-        // FIXME: Should we unwrap here?
-        let dec = ctx.get_function(&generic_name).unwrap().clone();
-
-        // FIXME: This is a little weird
-        if self.generics.is_empty() && dec.generics().is_empty() {
-            return;
-        }
-
-        // FIXME: This doesnt have all the actual types? T (b's type) is missing (464_arg_ty.jk)
-        // So we actually need to only map argument from the dec's arguments which are generic. Not
-        // all of them. Get a list of indexes or something from the dec and fetch those argument
-        // types only
-        // FIXME: We can only have actual types here: Not void, not unknown, nothing
-        let _resolved_types: Vec<TypeId> = self
-            .args
-            .iter_mut()
-            .map(|arg| match arg.type_of(ctx) {
-                Ok(CheckedType::Resolved(ty)) => ty,
-                _ => TypeId::void(),
-                // FIXME: Is this the correct behavior? The error
-                // will already have been emitted at this point
-            })
-            .collect();
-
-        // FIXME: Do we need this?
-        // self.args.iter_mut().for_each(|arg| arg.resolve_self(ctx));
-
-        self.fn_name = generic_name;
-        self.generics = vec![];
-
-        self.args
-            .iter_mut()
-            .for_each(|arg| arg.resolve_usages(type_map, ctx));
-
-        // FIXME: This is ugly as sin
-        if ctx.get_specialized_node(&self.fn_name).is_none() && self.fn_name != old_name {
-            let demangled = generics::demangle(&self.fn_name);
-
-            // FIXME: Can we unwrap here? Probably not
-            let generic_dec = ctx.get_function(demangled).unwrap().clone();
-            let specialized_fn = generic_dec.generate(self.fn_name.clone(), type_map, ctx);
-            ctx.add_specialized_node(SpecializedNode::Func(Box::new(specialized_fn)));
-        }
     }
 }
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -5,7 +5,6 @@ use std::fmt::Write;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{GenericExpander, GenericMap, GenericUser};
 use crate::instance::ObjectInstance;
 use crate::instruction::{Block, DecArg, InstrKind, Instruction};
 use crate::location::{Location, SpanTuple};
@@ -324,44 +323,6 @@ impl TypeCheck for FunctionDec {
             true => Some(&CheckedType::Void),
             false => None,
         }
-    }
-}
-
-impl GenericUser for FunctionDec {
-    fn resolve_usages(&mut self, _type_map: &GenericMap, ctx: &mut TypeCtx) {
-        // FIXME: Can we do without that?
-        if let Err(e) = ctx.declare_function(self.name().to_string(), self.clone()) {
-            ctx.error(e);
-        };
-    }
-}
-
-impl GenericExpander for FunctionDec {
-    fn generate(
-        &self,
-        mangled_name: String,
-        type_map: &GenericMap,
-        ctx: &mut TypeCtx,
-    ) -> FunctionDec {
-        let mut new_fn = self.clone();
-        new_fn.name = mangled_name;
-        new_fn.generics = vec![];
-        new_fn.typechecked = false;
-
-        new_fn
-            .args
-            .iter_mut()
-            .for_each(|arg| arg.resolve_usages(type_map, ctx));
-
-        if let Some(ret_ty) = &mut new_fn.ty {
-            ret_ty.resolve_usages(type_map, ctx);
-        }
-
-        if let Some(b) = &mut new_fn.block {
-            b.resolve_usages(type_map, ctx);
-        }
-
-        new_fn
     }
 }
 

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -237,14 +237,14 @@ impl Instruction for FunctionDec {
 }
 
 impl TypeCheck for FunctionDec {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         // FIXME Do not declare test functions in the typechecker? But typecheck
         // them still? Is this the correct behavior?
         if self.fn_kind() == FunctionKind::Test || self.fn_kind() == FunctionKind::Mock {
             return self
                 .block
                 .as_mut()
-                .map_or(CheckedType::Void, |b| b.type_of(ctx));
+                .map_or(Ok(CheckedType::Void), |b| b.type_of(ctx));
         }
 
         // If a declaration contains generic types, there is no point in type-checking
@@ -253,12 +253,9 @@ impl TypeCheck for FunctionDec {
         if !self.generics.is_empty() {
             // Just declare the function so we have it in the context and can
             // duplicate it
-            if let Err(e) = ctx.declare_generic_function(self.name().into(), self.clone()) {
-                ctx.error(e);
-                return CheckedType::Error;
-            }
+            ctx.declare_function(self.name().into(), self.clone())?;
 
-            return CheckedType::Later;
+            return Ok(CheckedType::Later);
         }
 
         // FIXME: Remove clone?
@@ -295,29 +292,27 @@ impl TypeCheck for FunctionDec {
 
         // If the function has no block, trust the declaration
         if let Some(b) = &mut self.block {
-            let block_ty = b.type_of(ctx);
+            let block_ty = b.type_of(ctx)?;
 
             if block_ty != return_ty {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!(
-                    "invalid type returned in function `{}`: expected type {}, found type {}",
-                    self.name(),
-                    return_ty,
-                    block_ty
-                ))
-                        .with_loc(self.loc()),
-                );
+                let err = Err(Error::new(ErrKind::TypeChecker)
+                    .with_msg(format!(
+                        "invalid type returned in function `{}`: expected type {}, found type {}",
+                        self.name(),
+                        return_ty,
+                        block_ty
+                    ))
+                    .with_loc(self.loc()));
 
                 ctx.scope_exit();
 
-                return CheckedType::Error;
+                return err;
             }
         }
 
         ctx.scope_exit();
 
-        CheckedType::Void
+        Ok(CheckedType::Void)
     }
 
     fn set_cached_type(&mut self, _ty: CheckedType) {
@@ -465,7 +460,6 @@ mod tests {
         let mut ctx = Context::new(Box::new(crate::io_trait::JkStdReader));
 
         assert!(ctx.type_check(&mut function).is_err());
-        assert!(ctx.error_handler.has_errors());
     }
 
     #[test]

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -17,7 +17,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{GenericMap, GenericUser};
 use crate::instance::{FromObjectInstance, ObjectInstance};
 use crate::instruction::{Block, InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -140,16 +139,6 @@ impl TypeCheck for IfElse {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for IfElse {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        self.condition.resolve_usages(type_map, ctx);
-        self.if_body.resolve_usages(type_map, ctx);
-        if let Some(b) = &mut self.else_body {
-            b.resolve_usages(type_map, ctx)
-        };
     }
 }
 

--- a/src/instruction/if_else.rs
+++ b/src/instruction/if_else.rs
@@ -91,55 +91,46 @@ impl Instruction for IfElse {
 }
 
 impl TypeCheck for IfElse {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let bool_checkedtype = CheckedType::Resolved(TypeId::from("bool"));
-        let cond_ty = self.condition.type_of(ctx);
+        let cond_ty = self.condition.type_of(ctx)?;
 
         if cond_ty != bool_checkedtype {
-            ctx.error(
-                Error::new(ErrKind::TypeChecker)
-                    .with_msg(format!(
-                        "if condition should be a boolean, not a `{}`",
-                        cond_ty
-                    ))
-                    .with_loc(self.condition.location().cloned()),
-            );
+            return Err(Error::new(ErrKind::TypeChecker)
+                .with_msg(format!(
+                    "if condition should be a boolean, not a `{}`",
+                    cond_ty
+                ))
+                .with_loc(self.condition.location().cloned()));
         }
 
-        let if_ty = self.if_body.type_of(ctx);
+        let if_ty = self.if_body.type_of(ctx)?;
         let else_ty = self
             .else_body
             .as_mut()
             .map(|else_body| else_body.type_of(ctx));
 
         match (if_ty, else_ty) {
-            (CheckedType::Void, None) => CheckedType::Void,
+            (CheckedType::Void, None) => Ok(CheckedType::Void),
             (if_ty, Some(else_ty)) => {
+                let else_ty = else_ty?;
                 if if_ty != else_ty {
-                    ctx.error(
-                        Error::new(ErrKind::TypeChecker)
-                            .with_msg(format!(
-                                "incompatible types for `if` and `else` block: {} and {}",
-                                if_ty, else_ty,
-                            ))
-                            .with_loc(self.location.clone()),
-                    );
-                    CheckedType::Error
+                    Err(Error::new(ErrKind::TypeChecker)
+                        .with_msg(format!(
+                            "incompatible types for `if` and `else` block: {} and {}",
+                            if_ty, else_ty,
+                        ))
+                        .with_loc(self.location.clone()))
                 } else {
-                    if_ty
+                    Ok(if_ty)
                 }
             }
-            (if_ty, None) => {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!(
-                            "`if` block has a return type ({}) but no else block to match it",
-                            if_ty
-                        ))
-                        .with_loc(self.location.clone()),
-                );
-                CheckedType::Error
-            }
+            (if_ty, None) => Err(Error::new(ErrKind::TypeChecker)
+                .with_msg(format!(
+                    "`if` block has a return type ({}) but no else block to match it",
+                    if_ty
+                ))
+                .with_loc(self.location.clone())),
         }
     }
 

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -7,7 +7,6 @@ use nom_locate::LocatedSpan;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::GenericUser;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction};
 use crate::io_trait::JkReader;
@@ -201,7 +200,7 @@ impl TypeCheck for Incl {
             return Ok(CheckedType::Void);
         }
 
-        let instructions = self.fetch_instructions(&final_path)?;
+        let instructions = self.fetch_instructions(&final_path, ctx.reader())?;
 
         self.instructions = instructions;
 
@@ -234,8 +233,6 @@ impl TypeCheck for Incl {
         }
     }
 }
-
-impl GenericUser for Incl {}
 
 #[cfg(test)]
 mod tests {

--- a/src/instruction/incl.rs
+++ b/src/instruction/incl.rs
@@ -174,7 +174,7 @@ impl Instruction for Incl {
 
 impl TypeCheck for Incl {
     // FIXME: We need to not add the path to the interpreter here
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let base = match &self.base {
             Some(b) => b.clone(),
             None => match ctx.path() {
@@ -193,21 +193,15 @@ impl TypeCheck for Incl {
             Err((e1, e2)) => {
                 ctx.error(e1);
                 ctx.error(e2);
-                return CheckedType::Error;
+                return Err(Error::new(ErrKind::TypeChecker));
             }
         };
 
         if ctx.is_included(&final_path) {
-            return CheckedType::Void;
+            return Ok(CheckedType::Void);
         }
 
-        let instructions = match self.fetch_instructions(&final_path, ctx.reader()) {
-            Ok(instructions) => instructions,
-            Err(e) => {
-                ctx.error(e);
-                return CheckedType::Error;
-            }
-        };
+        let instructions = self.fetch_instructions(&final_path)?;
 
         self.instructions = instructions;
 
@@ -218,13 +212,15 @@ impl TypeCheck for Incl {
         ctx.set_path(Some(final_path));
 
         self.instructions.iter_mut().for_each(|instr| {
-            instr.type_of(ctx);
+            if let Err(e) = instr.type_of(ctx) {
+                ctx.error(e);
+            }
         });
 
         // Reset the old path before leaving the instruction
         ctx.set_path(old_path);
 
-        CheckedType::Void
+        Ok(CheckedType::Void)
     }
 
     fn set_cached_type(&mut self, _ty: CheckedType) {

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -5,7 +5,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::GenericUser;
 use crate::instance::ObjectInstance;
 use crate::instruction::{FunctionCall, InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -93,8 +92,6 @@ impl TypeCheck for JkInst {
         Some(&CheckedType::Void)
     }
 }
-
-impl GenericUser for JkInst {}
 
 #[cfg(test)]
 mod tests {

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -83,8 +83,8 @@ impl Instruction for JkInst {
 }
 
 impl TypeCheck for JkInst {
-    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> CheckedType {
-        CheckedType::Void
+    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        Ok(CheckedType::Void)
     }
 
     fn set_cached_type(&mut self, _ty: CheckedType) {}

--- a/src/instruction/jk_return.rs
+++ b/src/instruction/jk_return.rs
@@ -10,7 +10,8 @@
 //! ```
 
 use crate::context::Context;
-use crate::generics::GenericUser;
+use crate::error::Error;
+use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -68,9 +69,9 @@ impl Instruction for Return {
 }
 
 impl TypeCheck for Return {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         match &mut self.value {
-            None => CheckedType::Void,
+            None => Ok(CheckedType::Void),
             Some(v) => v.type_of(ctx),
         }
     }

--- a/src/instruction/jk_return.rs
+++ b/src/instruction/jk_return.rs
@@ -11,7 +11,6 @@
 
 use crate::context::Context;
 use crate::error::Error;
-use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction};
 use crate::location::SpanTuple;
@@ -84,8 +83,6 @@ impl TypeCheck for Return {
         self.cached_type.as_ref()
     }
 }
-
-impl GenericUser for Return {}
 
 #[cfg(test)]
 mod tests {

--- a/src/instruction/loop_block.rs
+++ b/src/instruction/loop_block.rs
@@ -2,7 +2,8 @@
 //! different kinds, `for`, `while` or `loop`.
 
 use crate::context::Context;
-use crate::generics::GenericUser;
+use crate::error::Error;
+use crate::generics::Generic;
 use crate::instance::{FromObjectInstance, ObjectInstance};
 use crate::instruction::{Block, FunctionCall, InstrKind, Instruction, Var};
 use crate::location::SpanTuple;
@@ -207,7 +208,8 @@ impl Instruction for Loop {
 }
 
 impl TypeCheck for Loop {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        // FIXME: This is invalid
         self.block.type_of(ctx)
     }
 

--- a/src/instruction/loop_block.rs
+++ b/src/instruction/loop_block.rs
@@ -3,7 +3,6 @@
 
 use crate::context::Context;
 use crate::error::Error;
-use crate::generics::Generic;
 use crate::instance::{FromObjectInstance, ObjectInstance};
 use crate::instruction::{Block, FunctionCall, InstrKind, Instruction, Var};
 use crate::location::SpanTuple;
@@ -221,8 +220,6 @@ impl TypeCheck for Loop {
         self.cached_type.as_ref()
     }
 }
-
-impl GenericUser for Loop {}
 
 #[cfg(test)]
 mod tests {

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -2,7 +2,8 @@
 //! they get desugared into a normal function call.
 
 use crate::context::Context;
-use crate::generics::GenericUser;
+use crate::error::Error;
+use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::FunctionCall;
 use crate::instruction::{InstrKind, Instruction};
@@ -60,7 +61,10 @@ impl Instruction for MethodCall {
 }
 
 impl TypeCheck for MethodCall {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        log!("typechecking method `{}`", self.method.name());
+        log!("desugaring method `{}`", self.print());
+
         let mut call = self.method.clone();
 
         call.add_arg_front(self.var.clone());

--- a/src/instruction/method_call.rs
+++ b/src/instruction/method_call.rs
@@ -3,7 +3,6 @@
 
 use crate::context::Context;
 use crate::error::Error;
-use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::FunctionCall;
 use crate::instruction::{InstrKind, Instruction};
@@ -62,9 +61,6 @@ impl Instruction for MethodCall {
 
 impl TypeCheck for MethodCall {
     fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
-        log!("typechecking method `{}`", self.method.name());
-        log!("desugaring method `{}`", self.print());
-
         let mut call = self.method.clone();
 
         call.add_arg_front(self.var.clone());
@@ -88,13 +84,6 @@ impl TypeCheck for MethodCall {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for MethodCall {
-    fn resolve_usages(&mut self, type_map: &crate::generics::GenericMap, ctx: &mut TypeCtx) {
-        // FIXME: Can we avoid adding the argument here?
-        self.method.resolve_usages(type_map, ctx);
     }
 }
 

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -3,7 +3,7 @@ use super::{DecArg, InstrKind, Instruction};
 use std::fmt::Write;
 
 use crate::context::Context;
-use crate::generics::{GenericExpander, GenericMap, GenericUser};
+use crate::error::Error;
 use crate::instance::ObjectInstance;
 use crate::location::SpanTuple;
 use crate::typechecker::{CheckedType, TypeCheck, TypeCtx, TypeId};
@@ -118,31 +118,6 @@ impl TypeCheck for TypeDec {
             true => Some(&CheckedType::Void),
             false => None,
         }
-    }
-}
-
-impl GenericUser for TypeDec {
-    fn resolve_usages(&mut self, _type_map: &GenericMap, ctx: &mut TypeCtx) {
-        // FIXME: Can we do without that?
-        if let Err(e) = ctx.declare_custom_type(self.name().to_string(), self.clone()) {
-            ctx.error(e);
-        };
-    }
-}
-
-impl GenericExpander for TypeDec {
-    fn generate(&self, mangled_name: String, type_map: &GenericMap, ctx: &mut TypeCtx) -> TypeDec {
-        let mut new_type = self.clone();
-        new_type.name = mangled_name;
-        new_type.generics = vec![];
-        new_type.typechecked = false;
-
-        new_type
-            .fields
-            .iter_mut()
-            .for_each(|arg| arg.resolve_usages(type_map, ctx));
-
-        new_type
     }
 }
 

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -103,12 +103,10 @@ impl Instruction for TypeDec {
 }
 
 impl TypeCheck for TypeDec {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
-        if let Err(e) = ctx.declare_custom_type(self.name.clone(), self.clone()) {
-            ctx.error(e);
-        }
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        ctx.declare_custom_type(self.name.clone(), self.clone())?;
 
-        CheckedType::Void
+        Ok(CheckedType::Void)
     }
 
     fn set_cached_type(&mut self, _ty: CheckedType) {

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -3,12 +3,10 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{self, GenericExpander, GenericMap, GenericUser};
 use crate::instance::{Name, ObjectInstance};
 use crate::instruction::{InstrKind, Instruction, TypeDec, VarAssign};
 use crate::location::SpanTuple;
-use crate::symbol::Symbol;
-use crate::typechecker::{CheckedType, SpecializedNode, TypeCheck, TypeCtx, TypeId};
+use crate::typechecker::{CheckedType, TypeCheck, TypeCtx, TypeId};
 
 use std::rc::Rc;
 
@@ -87,34 +85,6 @@ impl TypeInstantiation {
     pub fn set_location(&mut self, location: SpanTuple) {
         self.location = Some(location)
     }
-
-    pub fn resolve_generic_instantiation(
-        &mut self,
-        dec: TypeDec,
-        ctx: &mut TypeCtx,
-    ) -> Result<CheckedType, Error> {
-        log!(
-            "creating specialized type. type generics: {}, instantiation generics {}",
-            dec.generics().len(),
-            self.generics.len()
-        );
-        let type_map = GenericMap::create(dec.generics(), &self.generics, ctx)?;
-
-        let specialized_name = generics::mangle(dec.name(), &self.generics);
-        if ctx.get_custom_type(&specialized_name).is_none() {
-            // FIXME: Remove this clone once we have proper symbols
-            let specialized_ty = dec.from_type_map(specialized_name.clone(), &type_map, ctx)?;
-
-            ctx.add_specialized_node(SpecializedNode::Type(specialized_ty))?;
-        }
-
-        self.type_name = TypeId::new(Symbol::from(specialized_name));
-        self.generics = vec![];
-
-        // Recursively resolve the type of self now that we changed the
-        // function to call
-        self.type_of(ctx)
-    }
 }
 
 impl Instruction for TypeInstantiation {
@@ -187,9 +157,9 @@ impl TypeCheck for TypeInstantiation {
             }
         };
 
-        if !dec.generics().is_empty() || !self.generics.is_empty() {
-            return self.resolve_generic_instantiation(dec, ctx);
-        }
+        // if !dec.generics().is_empty() || !self.generics.is_empty() {
+        //     return self.resolve_generic_instantiation(dec, ctx);
+        // }
 
         let mut errors = vec![];
         for (field_dec, var_assign) in dec.fields().iter().zip(self.fields.iter_mut()) {
@@ -226,47 +196,6 @@ impl TypeCheck for TypeInstantiation {
 
     fn cached_type(&self) -> Option<&CheckedType> {
         self.cached_type.as_ref()
-    }
-}
-
-impl GenericUser for TypeInstantiation {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        let dec = match ctx.get_custom_type(self.type_name.id()) {
-            Some(t) => t,
-            None => {
-                ctx.error(Error::new(ErrKind::Generics).with_msg(format!("trying to access undeclared type when resolving generic type instantiation: `{}`", self.type_name)).with_loc(self.location.clone()));
-                return;
-            }
-        };
-
-        let new_types = match type_map.specialized_types(dec.generics()) {
-            Err(e) => {
-                ctx.error(e.with_loc(self.location().cloned()));
-                return;
-            }
-            Ok(new_t) => new_t,
-        };
-
-        let new_name = generics::mangle(self.type_name.id(), &new_types);
-        let old_name = String::from(self.type_name.id());
-        self.type_name = TypeId::new(Symbol::from(new_name.clone()));
-        self.generics = vec![];
-
-        self.fields
-            .iter_mut()
-            .for_each(|arg| arg.resolve_usages(type_map, ctx));
-
-        // FIXME: This is ugly as sin
-        if ctx.get_specialized_node(self.type_name.id()).is_none()
-            && self.type_name.id() != old_name
-        {
-            let demangled = generics::demangle(self.type_name.id());
-
-            // FIXME: Can we unwrap here? Probably not
-            let generic_dec = ctx.get_custom_type(demangled).unwrap().clone();
-            let specialized_ty = generic_dec.generate(new_name, type_map, ctx);
-            ctx.add_specialized_node(SpecializedNode::Type(specialized_ty));
-        }
     }
 }
 

--- a/src/instruction/type_instantiation.rs
+++ b/src/instruction/type_instantiation.rs
@@ -92,21 +92,20 @@ impl TypeInstantiation {
         &mut self,
         dec: TypeDec,
         ctx: &mut TypeCtx,
-    ) -> CheckedType {
-        let type_map = match GenericMap::create(dec.generics(), &self.generics, ctx) {
-            Ok(map) => map,
-            Err(e) => {
-                ctx.error(e.with_loc(self.location.clone()));
-                return CheckedType::Error;
-            }
-        };
+    ) -> Result<CheckedType, Error> {
+        log!(
+            "creating specialized type. type generics: {}, instantiation generics {}",
+            dec.generics().len(),
+            self.generics.len()
+        );
+        let type_map = GenericMap::create(dec.generics(), &self.generics, ctx)?;
 
         let specialized_name = generics::mangle(dec.name(), &self.generics);
         if ctx.get_custom_type(&specialized_name).is_none() {
             // FIXME: Remove this clone once we have proper symbols
-            let specialized_ty = dec.generate(specialized_name.clone(), &type_map, ctx);
+            let specialized_ty = dec.from_type_map(specialized_name.clone(), &type_map, ctx)?;
 
-            ctx.add_specialized_node(SpecializedNode::Type(specialized_ty));
+            ctx.add_specialized_node(SpecializedNode::Type(specialized_ty))?;
         }
 
         self.type_name = TypeId::new(Symbol::from(specialized_name));
@@ -174,20 +173,17 @@ impl Instruction for TypeInstantiation {
 }
 
 impl TypeCheck for TypeInstantiation {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let dec = match ctx.get_custom_type(self.type_name.id()) {
             Some(ty) => ty.clone(),
             None => {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!(
-                            "use of undeclared type `{}`",
-                            // FIXME: Remove this clone, not useful
-                            CheckedType::Resolved(self.type_name.clone())
-                        ))
-                        .with_loc(self.location.clone()),
-                );
-                return CheckedType::Error;
+                return Err(Error::new(ErrKind::TypeChecker)
+                    .with_msg(format!(
+                        "use of undeclared type `{}`",
+                        // FIXME: Remove this clone, not useful
+                        CheckedType::Resolved(self.type_name.clone())
+                    ))
+                    .with_loc(self.location.clone()));
             }
         };
 
@@ -198,7 +194,7 @@ impl TypeCheck for TypeInstantiation {
         let mut errors = vec![];
         for (field_dec, var_assign) in dec.fields().iter().zip(self.fields.iter_mut()) {
             let expected_ty = CheckedType::Resolved(field_dec.get_type().clone());
-            let value_ty = var_assign.value_mut().type_of(ctx);
+            let value_ty = var_assign.value_mut().type_of(ctx)?;
             if expected_ty != value_ty {
                 errors.push(
                     Error::new(ErrKind::TypeChecker)
@@ -221,7 +217,7 @@ impl TypeCheck for TypeInstantiation {
         // Propagate all errors at once in the context
         errors.into_iter().for_each(|err| ctx.error(err));
 
-        CheckedType::Resolved(self.type_name.clone())
+        Ok(CheckedType::Resolved(self.type_name.clone()))
     }
 
     fn set_cached_type(&mut self, ty: CheckedType) {

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -105,16 +105,15 @@ impl Instruction for Var {
 }
 
 impl TypeCheck for Var {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn type_log(&self) -> String {
+        self.name.to_string()
+    }
+
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         match ctx.get_var(self.name()) {
-            Some(var_ty) => var_ty.clone(),
-            None => {
-                ctx.error(
-                    Error::new(ErrKind::TypeChecker)
-                        .with_msg(format!("use of undeclared variable: `{}`", self.name())),
-                );
-                CheckedType::Error
-            }
+            Some(var_ty) => Ok(var_ty.clone()),
+            None => Err(Error::new(ErrKind::TypeChecker)
+                .with_msg(format!("use of undeclared variable: `{}`", self.name()))),
         }
     }
 

--- a/src/instruction/var.rs
+++ b/src/instruction/var.rs
@@ -5,7 +5,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::GenericUser;
 use crate::instance::ObjectInstance;
 use crate::instruction::TypeDec;
 use crate::instruction::{InstrKind, Instruction};
@@ -105,10 +104,6 @@ impl Instruction for Var {
 }
 
 impl TypeCheck for Var {
-    fn type_log(&self) -> String {
-        self.name.to_string()
-    }
-
     fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         match ctx.get_var(self.name()) {
             Some(var_ty) => Ok(var_ty.clone()),
@@ -131,8 +126,6 @@ impl Default for Var {
         Var::new(String::new())
     }
 }
-
-impl GenericUser for Var {}
 
 #[cfg(test)]
 mod tests {

--- a/src/instruction/var_assignment.rs
+++ b/src/instruction/var_assignment.rs
@@ -2,7 +2,6 @@
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::{GenericMap, GenericUser};
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction, Var};
 use crate::location::SpanTuple;
@@ -197,12 +196,6 @@ impl TypeCheck for VarAssign {
     }
 }
 
-impl GenericUser for VarAssign {
-    fn resolve_usages(&mut self, type_map: &GenericMap, ctx: &mut TypeCtx) {
-        self.value.resolve_usages(type_map, ctx)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,6 +293,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Generics not re-implemented yet #587"]
     fn generic_builtin_for_var_assign() {
         jinko! {
             a = 156;

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
-use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction, TypeInstantiation, Var};
 use crate::location::SpanTuple;
@@ -118,5 +117,3 @@ impl TypeCheck for VarOrEmptyType {
         self.cached_type.as_ref()
     }
 }
-
-impl GenericUser for VarOrEmptyType {}

--- a/src/instruction/var_or_empty_type.rs
+++ b/src/instruction/var_or_empty_type.rs
@@ -1,12 +1,13 @@
 use crate::context::Context;
-use crate::generics::GenericUser;
+use crate::error::{ErrKind, Error};
+use crate::generics::Generic;
 use crate::instance::ObjectInstance;
 use crate::instruction::{InstrKind, Instruction, TypeInstantiation, Var};
 use crate::location::SpanTuple;
 use crate::symbol::Symbol;
 use crate::typechecker::{CheckedType, TypeCheck, TypeCtx, TypeId};
 
-#[derive(Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum Kind {
     Unknown,
     EmptyTypeInst,
@@ -81,19 +82,26 @@ impl Instruction for VarOrEmptyType {
 }
 
 impl TypeCheck for VarOrEmptyType {
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
         let kind = if self.kind == Kind::Unknown {
             self.resolve_kind(ctx)
         } else {
-            self.kind.clone()
+            self.kind
         };
 
         match kind {
-            Kind::Unknown => CheckedType::Error,
-            Kind::EmptyTypeInst => {
-                CheckedType::Resolved(TypeId::new(Symbol::from(self.symbol.clone())))
-            }
-            Kind::VarAccess => ctx.get_var(&self.symbol).unwrap().to_owned(),
+            Kind::Unknown => Ok(CheckedType::Error),
+            Kind::EmptyTypeInst => Ok(CheckedType::Resolved(TypeId::new(Symbol::from(
+                self.symbol.clone(),
+            )))),
+            Kind::VarAccess => ctx.get_var(&self.symbol).cloned().ok_or_else(|| {
+                Error::new(ErrKind::TypeChecker)
+                    .with_msg(format!(
+                        "trying to access undeclared variable `{}`",
+                        &self.symbol
+                    ))
+                    .with_loc(self.location().cloned())
+            }),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ pub mod debug;
 pub mod error;
 #[cfg(feature = "ffi")]
 mod ffi;
-pub mod generics;
+// FIXME: Re-add once we reimplement generics
+// pub mod generics;
 mod indent;
 pub mod instance;
 pub mod instruction;
@@ -21,7 +22,8 @@ pub mod value;
 pub use builtins::Builtins;
 pub use context::{Context, Scope, ScopeMap};
 pub use error::{ErrKind, Error};
-pub use generics::GenericUser;
+// FIXME: Re-add once we reimplement generics
+// pub use generics::GenericUser;
 pub use indent::Indent;
 pub use instance::{FromObjectInstance, ObjectInstance, ToObjectInstance};
 pub use instruction::{InstrKind, Instruction};

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -296,12 +296,9 @@ pub trait TypeCheck {
     /// This avoid typechecking an entire instruction a second time and allows the
     /// context to just access it. This is useful for passes such as generic expansion.
     fn type_of(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
-        log!("type_of value {}", self.type_log());
-
         // FIXME: Remove clones
         match self.cached_type() {
             None => {
-                log!("no cached type");
                 match self.resolve_type(ctx)? {
                     CheckedType::Resolved(new_ty) => {
                         self.set_cached_type(CheckedType::Resolved(new_ty.clone()));
@@ -317,10 +314,7 @@ pub trait TypeCheck {
                     CheckedType::Later => Ok(CheckedType::Later),
                 }
             }
-            Some(ty) => {
-                log!("cached type!: {}", ty);
-                Ok(ty.clone())
-            }
+            Some(ty) => Ok(ty.clone()),
         }
     }
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -193,13 +193,15 @@ impl TypeCtx {
     }
 
     /// Add a new generated node to the context
-    pub fn add_specialized_node(&mut self, mut node: SpecializedNode) {
+    pub fn add_specialized_node(&mut self, mut node: SpecializedNode) -> Result<(), Error> {
         match &mut node {
-            SpecializedNode::Func(f) => f.type_of(self),
-            SpecializedNode::Type(t) => t.type_of(self),
+            SpecializedNode::Func(f) => f.type_of(self)?,
+            SpecializedNode::Type(t) => t.type_of(self)?,
         };
 
-        self.generated.push(node)
+        self.generated.push(node);
+
+        Ok(())
     }
 
     /// Get a reference to a newly generated node
@@ -282,7 +284,7 @@ pub trait TypeCheck {
     /// Go through the context in order to figure out the type of an instruction.
     /// This function should report errors using the context, and the [`ErrKind::TypeCheck`]
     /// error kind.
-    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> CheckedType;
+    fn resolve_type(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error>;
 
     /// Cache the type of an instruction
     fn set_cached_type(&mut self, ty: CheckedType);
@@ -293,22 +295,32 @@ pub trait TypeCheck {
     /// Access the cached type of an instruction or perform the type resolution process.
     /// This avoid typechecking an entire instruction a second time and allows the
     /// context to just access it. This is useful for passes such as generic expansion.
-    fn type_of(&mut self, ctx: &mut TypeCtx) -> CheckedType {
+    fn type_of(&mut self, ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        log!("type_of value {}", self.type_log());
+
         // FIXME: Remove clones
         match self.cached_type() {
-            None => match self.resolve_type(ctx) {
-                CheckedType::Resolved(new_ty) => {
-                    self.set_cached_type(CheckedType::Resolved(new_ty.clone()));
-                    CheckedType::Resolved(new_ty)
+            None => {
+                log!("no cached type");
+                match self.resolve_type(ctx)? {
+                    CheckedType::Resolved(new_ty) => {
+                        self.set_cached_type(CheckedType::Resolved(new_ty.clone()));
+                        Ok(CheckedType::Resolved(new_ty))
+                    }
+                    CheckedType::Void => {
+                        self.set_cached_type(CheckedType::Void);
+                        Ok(CheckedType::Void)
+                    }
+                    // FIXME: How do we deal with CheckedType::Error now that we
+                    // have emission sites and aggreg. sites? Remove it?
+                    CheckedType::Error => Ok(CheckedType::Error),
+                    CheckedType::Later => Ok(CheckedType::Later),
                 }
-                CheckedType::Void => {
-                    self.set_cached_type(CheckedType::Void);
-                    CheckedType::Void
-                }
-                CheckedType::Error => CheckedType::Error,
-                CheckedType::Later => CheckedType::Later,
-            },
-            Some(ty) => ty.clone(),
+            }
+            Some(ty) => {
+                log!("cached type!: {}", ty);
+                Ok(ty.clone())
+            }
         }
     }
 }

--- a/src/typechecker/type_id.rs
+++ b/src/typechecker/type_id.rs
@@ -27,11 +27,8 @@ use std::hash::Hash;
 
 use colored::Colorize;
 
-use crate::error::{ErrKind, Error};
-use crate::generics::{self, GenericExpander, GenericUser};
 use crate::instruction::TypeDec;
 use crate::symbol::Symbol;
-use crate::typechecker::SpecializedNode;
 
 pub const PRIMITIVE_TYPES: [&str; 5] = ["bool", "int", "float", "char", "string"];
 
@@ -158,68 +155,9 @@ impl TypeId {
         TypeId::new(Symbol::from(String::from("void")))
     }
 
-    fn set_id(&mut self, new_id: Symbol) {
-        if let TypeId::Type { id, .. } = self {
-            *id = new_id;
-        }
-    }
-
     #[deprecated]
     pub fn is_primitive(&self) -> bool {
         PRIMITIVE_TYPES.contains(&self.id())
-    }
-}
-
-impl GenericUser for TypeId {
-    fn resolve_usages(&mut self, type_map: &crate::generics::GenericMap, ctx: &mut crate::TypeCtx) {
-        let generics = match self {
-            TypeId::Type { generics, .. } => generics,
-            TypeId::Functor { generics, .. } => generics,
-        };
-
-        // FIXME: Split generics in two using .partition(): Keep some in a new
-        // generic list, and resolve some others to the type's name
-        let new_types = match type_map.specialized_types(generics) {
-            Err(e) => {
-                ctx.error(e);
-                return;
-            }
-            Ok(new_t) => new_t,
-        };
-
-        // FIXME: What we need to do then is to go and visit all our newtype's generics
-        // and resolve them
-
-        generics.clear();
-
-        if let Ok(new_id) = type_map.get_specialized(self) {
-            self.set_id(Symbol::from(String::from(new_id.id())));
-        }
-
-        if let TypeId::Type { id, .. } = self {
-            let new_name = generics::mangle(id.access(), &new_types);
-
-            // If the type does not exist yet, then we must create it and add it to the specialized
-            // nodes
-            let type_dec = ctx.get_custom_type(&new_name);
-            if type_dec.is_none() {
-                let new_dec = match ctx.get_custom_type(id.access()) {
-                    Some(t) => t.clone(),
-                    None => {
-                        ctx.error(
-                            Error::new(ErrKind::Generics)
-                                // FIXME: How do we get the location here?
-                                .with_msg(format!("undeclared generic type `{}`", self)),
-                        );
-                        return;
-                    }
-                };
-                let new_dec = new_dec.generate(new_name.clone(), type_map, ctx);
-                ctx.add_specialized_node(SpecializedNode::Type(new_dec));
-            }
-
-            *id = Symbol::from(new_name);
-        }
     }
 }
 

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -126,8 +126,8 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<bool> {
-            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
-                CheckedType::Resolved(TypeId::from("bool"))
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> Result<CheckedType, Error> {
+                Ok(CheckedType::Resolved(TypeId::from("bool")))
             }
 
             fn set_cached_type(&mut self, _: CheckedType) {}
@@ -196,8 +196,8 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<char> {
-            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
-                CheckedType::Resolved(TypeId::from("char"))
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> Result<CheckedType, Error> {
+                Ok(CheckedType::Resolved(TypeId::from("char")))
             }
 
             fn set_cached_type(&mut self, _: CheckedType) {}
@@ -256,8 +256,8 @@ macro_rules! jk_primitive {
         }
 
         impl TypeCheck for JkConstant<$t> {
-            fn resolve_type(&mut self, _: &mut TypeCtx) -> CheckedType {
-                CheckedType::Resolved(TypeId::from($s))
+            fn resolve_type(&mut self, _: &mut TypeCtx) -> Result<CheckedType, Error> {
+                Ok(CheckedType::Resolved(TypeId::from($s)))
             }
 
             fn set_cached_type(&mut self, _: CheckedType) {}
@@ -354,8 +354,8 @@ impl Instruction for JkString {
 }
 
 impl TypeCheck for JkString {
-    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> CheckedType {
-        CheckedType::Resolved(TypeId::from("string"))
+    fn resolve_type(&mut self, _ctx: &mut TypeCtx) -> Result<CheckedType, Error> {
+        Ok(CheckedType::Resolved(TypeId::from("string")))
     }
 
     fn set_cached_type(&mut self, _: CheckedType) {}

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -1,6 +1,5 @@
 use crate::context::Context;
 use crate::error::Error;
-use crate::generics::GenericUser;
 use crate::instance::{FromObjectInstance, ObjectInstance, ToObjectInstance};
 use crate::instruction::{InstrKind, Instruction, Operator};
 use crate::location::SpanTuple;
@@ -136,8 +135,6 @@ macro_rules! jk_primitive {
                 Some(&self.1)
             }
         }
-
-        impl GenericUser for JkConstant<bool> {}
     };
     (char) => {
         impl ToObjectInstance for JkConstant<char> {
@@ -206,8 +203,6 @@ macro_rules! jk_primitive {
                 Some(&self.1)
             }
         }
-
-        impl GenericUser for JkConstant<char> {}
     };
     ($t:ty, $s:expr) => {
         impl ToObjectInstance for JkConstant<$t> {
@@ -266,8 +261,6 @@ macro_rules! jk_primitive {
                 Some(&self.1)
             }
         }
-
-        impl GenericUser for JkConstant<$t> {}
 
         impl From<$t> for JkConstant<$t> {
             fn from(rust_value: $t) -> Self {
@@ -364,8 +357,6 @@ impl TypeCheck for JkString {
         Some(&self.1)
     }
 }
-
-impl GenericUser for JkString {}
 
 impl From<&str> for JkConstant<String> {
     fn from(s: &str) -> Self {

--- a/tests/ft/generics/generics.yml
+++ b/tests/ft/generics/generics.yml
@@ -1,106 +1,116 @@
 tests:
-  - name: "Function with generic return value valid"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_return_type.jk"
-    exit_code: 0
+    - name: "Reimplement generics and remove me #587"
+      binary: echo
+      args:
+        - "#587"
+      exit_code: 0
+    # FIXME: #587
+    # - name: "Function with generic return value valid"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_return_type.jk"
+    #   exit_code: 0
     # FIXME: Do not ignore once #496 is fixed
     # - name: "Function with generic return value invalid"
     #   binary: "target/debug/jinko"
     #   args:
     #     - "tests/ft/generics/invalid_return_type.jk"
     #   exit_code: 1
-  - name: "Valid generic id()"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_id.jk"
-    exit_code: 0
-  - name: "Undeclared return type"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/undeclared_return_generic.jk"
-    exit_code: 1
+    # FIXME: #587
+    # - name: "Valid generic id()"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_id.jk"
+    #   exit_code: 0
+    # FIXME: #587
+    # - name: "Undeclared return type"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/undeclared_return_generic.jk"
+    #   exit_code: 1
     # FIXME: Do not ignore once #476 is fixed
     # - name: "Undeclared type in arguments"
     #   binary: "target/debug/jinko"
     #   args:
     #     - "tests/ft/generics/undeclared_arg_generic.jk"
     #   exit_code: 1
-  - name: "Valid call to same generic fn twice"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_call_generic_twice.jk"
-    exit_code: 0
-  - name: "Valid use of ducktyping"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_ducktyping.jk"
-    exit_code: 0
-  - name: "Valid multi-use of ducktyping"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_multiple_ducktyping.jk"
-    exit_code: 0
-  - name: "Invalid use of ducktyping"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/invalid_ducktyping.jk"
-    exit_code: 1
-  - name: "Valid generic on field access"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_field_access.jk"
-    exit_code: 159
-  - name: "Valid generic on if else block"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_if_else.jk"
-    exit_code: 0
-  - name: "Valid generic on method call"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_method_call.jk"
-    exit_code: 0
-  - name: "Invalid typechecking on function call"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/invalid_typechecking.jk"
-    exit_code: 1
-  - name: "Valid simple generic type"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_simple_type.jk"
-    exit_code: 15
-      # FIXME: Don't ignore once #408 is fixed
-      # - name: "Valid nested simple generic type"
-      #   binary: "target/debug/jinko"
-      #   args:
-      #     - "tests/ft/generics/valid_nested_type.jk"
-      #   exit_code: 15
-  - name: "Generic expansion in usage"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_type_when_resolving.jk"
-    exit_code: 15
-  - name: "Generic expansion in inner fn"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_inner_fn.jk"
-    exit_code: 15
-  - name: "Generic expansion in inner fn"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_inner_fn.jk"
-    exit_code: 15
-  - name: "Generic expansion in inner type"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/generics/valid_inner_type_when_resolving.jk"
-    exit_code: 15
-      # FIXME: Don't ignore to pass #408
-      # - name: "Generic stress test"
-      #   binary: "target/debug/jinko"
-      #   args:
-      #     - "--check"
-      #     - "tests/ft/generics/maybe_simple.jk"
-      #   exit_code: 0
+    # FIXME: #587
+    # - name: "Valid call to same generic fn twice"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_call_generic_twice.jk"
+    #   exit_code: 0
+    # FIXME: #587
+    # - name: "Valid use of ducktyping"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_ducktyping.jk"
+    #   exit_code: 0
+    # - name: "Valid multi-use of ducktyping"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_multiple_ducktyping.jk"
+    #   exit_code: 0
+    # - name: "Invalid use of ducktyping"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/invalid_ducktyping.jk"
+    #   exit_code: 1
+    # - name: "Valid generic on field access"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_field_access.jk"
+    #   exit_code: 159
+    # - name: "Valid generic on if else block"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_if_else.jk"
+    #   exit_code: 0
+    # - name: "Valid generic on method call"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_method_call.jk"
+    #   exit_code: 0
+    # - name: "Invalid typechecking on function call"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/invalid_typechecking.jk"
+    #   exit_code: 1
+    # - name: "Valid simple generic type"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_simple_type.jk"
+    #   exit_code: 15
+    #     # FIXME: Don't ignore once #408 is fixed
+    #     # - name: "Valid nested simple generic type"
+    #     #   binary: "target/debug/jinko"
+    #     #   args:
+    #     #     - "tests/ft/generics/valid_nested_type.jk"
+    #     #   exit_code: 15
+    # - name: "Generic expansion in usage"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_type_when_resolving.jk"
+    #   exit_code: 15
+    # - name: "Generic expansion in inner fn"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_inner_fn.jk"
+    #   exit_code: 15
+    # - name: "Generic expansion in inner fn"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_inner_fn.jk"
+    #   exit_code: 15
+    # - name: "Generic expansion in inner type"
+    #   binary: "target/debug/jinko"
+    #   args:
+    #     - "tests/ft/generics/valid_inner_type_when_resolving.jk"
+    #   exit_code: 15
+    #     # FIXME: Don't ignore to pass #408
+    #     # - name: "Generic stress test"
+    #     #   binary: "target/debug/jinko"
+    #     #   args:
+    #     #     - "--check"
+    #     #     - "tests/ft/generics/maybe_simple.jk"
+    #     #   exit_code: 0

--- a/tests/ft/regression/regression.yml
+++ b/tests/ft/regression/regression.yml
@@ -34,16 +34,18 @@ tests:
     args:
       - "tests/ft/regression/284.jk"
     exit_code: 0
-  - name: "Do not map non-generic return type #464"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/regression/464_return_ty.jk"
-    exit_code: 0
-  - name: "Do not map non-generic arg type #464"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/regression/464_arg_ty.jk"
-    exit_code: 0
+      # FIXME: #587
+      # - name: "Do not map non-generic return type #464"
+      #   binary: "target/debug/jinko"
+      #   args:
+      #     - "tests/ft/regression/464_return_ty.jk"
+      #   exit_code: 0
+      # FIXME: #587
+      # - name: "Do not map non-generic arg type #464"
+      #   binary: "target/debug/jinko"
+      #   args:
+      #     - "tests/ft/regression/464_arg_ty.jk"
+      #   exit_code: 0
   - name: "Test functions get declared during generics pass #468"
     binary: "target/debug/jinko"
     args:
@@ -56,8 +58,9 @@ tests:
       - "tests/ft/regression/468.jk"
     stdout: "in test!\n"
     exit_code: 0
-  - name: "Forbid calling non-generic fn with generic arguments #462"
-    binary: "target/debug/jinko"
-    args:
-      - "tests/ft/regression/462.jk"
-    exit_code: 1
+      # FIXME: #587
+      # - name: "Forbid calling non-generic fn with generic arguments #462"
+      #   binary: "target/debug/jinko"
+      #   args:
+      #     - "tests/ft/regression/462.jk"
+      #   exit_code: 1


### PR DESCRIPTION
In accordance with this writeup https://docs.jinko.ml/writeups/4-error-handling-inside-the-interpreter/

This now also removes generics as they are a pain in the ass and are implemented incorrectly.
Fixes #587 