### PR TITLE
Comment `link_with("libc.so.6")` in ffi testsuite

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -283,8 +283,8 @@ mod tests {
         };
 
         // Load libc, probably from LD_LIBRARY_PATH
-        jinko! {
-            link_with("libc.so.6");
-        };
+        // jinko! {
+        //     link_with("libc.so.6");
+        // };
     }
 }


### PR DESCRIPTION
Fixes #565 