### PR TITLE
Disable vec include in stdlib

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -57,7 +57,7 @@ impl ErrorHandler {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ErrKind {
     Hint,

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -3,6 +3,7 @@
 //! calls. Its basic goal is to replace all instances of `T` with an actual [`TypeId`].
 
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use crate::error::{ErrKind, Error};
 use crate::typechecker::{TypeCtx, TypeId};
@@ -25,12 +26,12 @@ impl GenericMap {
             let err_msg = String::from("missing types in generic expansion");
             let mut err_msg = format!("{}\ngeneric types: ", err_msg);
             for generic in generics {
-                err_msg.push_str(&format!("{}", generic));
+                write!(err_msg, "{}", generic).unwrap();
             }
 
             let mut err_msg = format!("{}\nresolved types: ", err_msg);
             for resolved in resolved {
-                err_msg.push_str(&format!("{}", resolved));
+                write!(err_msg, "{}", resolved).unwrap();
             }
 
             return Err(Error::new(ErrKind::Generics).with_msg(err_msg));

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -2,6 +2,7 @@
 //! function on execution.
 
 use std::rc::Rc;
+use std::fmt::Write;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
@@ -218,7 +219,7 @@ impl Instruction for FunctionCall {
             self.generics
                 .iter()
                 .skip(1)
-                .for_each(|generic| base.push_str(&format!(", {}", generic)));
+                .for_each(|generic| write!(base, "{}", generic).unwrap());
             base.push(']');
         }
 

--- a/src/instruction/function_call.rs
+++ b/src/instruction/function_call.rs
@@ -1,8 +1,8 @@
 //! FunctionCalls are used when calling a function. The argument list is given to the
 //! function on execution.
 
-use std::rc::Rc;
 use std::fmt::Write;
+use std::rc::Rc;
 
 use crate::context::Context;
 use crate::error::{ErrKind, Error};

--- a/src/instruction/function_declaration.rs
+++ b/src/instruction/function_declaration.rs
@@ -1,6 +1,8 @@
 //! Function Declarations are used when adding a new function to the source. They contain
 //! a name, a list of required arguments as well as an associated code block
 
+use std::fmt::Write;
+
 use crate::context::Context;
 use crate::error::{ErrKind, Error};
 use crate::generics::{GenericExpander, GenericMap, GenericUser};
@@ -11,7 +13,7 @@ use crate::typechecker::{CheckedType, TypeCheck, TypeCtx, TypeId};
 
 /// What "kind" of function is defined. There are four types of functions in jinko,
 /// the normal ones, the external ones, the unit tests and the mocks
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FunctionKind {
     Unknown,
     Func,
@@ -208,7 +210,7 @@ impl Instruction for FunctionDec {
 
         base.push('(');
         if !self.args.is_empty() {
-            base.push_str(&format!("{}", self.args().iter().next().unwrap()));
+            write!(base, "{}", self.args().iter().next().unwrap()).unwrap();
             let arg_str = self
                 .args
                 .iter()

--- a/src/instruction/jk_inst.rs
+++ b/src/instruction/jk_inst.rs
@@ -12,7 +12,7 @@ use crate::location::SpanTuple;
 use crate::typechecker::{CheckedType, TypeCheck, TypeCtx};
 
 /// The potential ctx instructions
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum JkInstKind {
     Dump,
     Quit,

--- a/src/instruction/operator.rs
+++ b/src/instruction/operator.rs
@@ -3,7 +3,7 @@
 
 /// All the binary operators available
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Operator {
     Add,
     Sub,

--- a/src/instruction/type_declaration.rs
+++ b/src/instruction/type_declaration.rs
@@ -1,5 +1,7 @@
 use super::{DecArg, InstrKind, Instruction};
 
+use std::fmt::Write;
+
 use crate::context::Context;
 use crate::generics::{GenericExpander, GenericMap, GenericUser};
 use crate::instance::ObjectInstance;
@@ -82,7 +84,7 @@ impl Instruction for TypeDec {
 
         if !self.fields.is_empty() {
             base.push('(');
-            base.push_str(&format!("{}", self.fields.first().unwrap()));
+            write!(base, "{}", self.fields.first().unwrap()).unwrap();
             let arg_str = self
                 .fields
                 .iter()

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -21,7 +21,7 @@ use std::{
 /// The [`CheckedType`] enum contains three possible states about the type. Either the
 /// type has been properly resolved to something, or it corresponds to a Void type. If the
 /// type has not been resolved yet, it can be unknown.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum CheckedType {
     Resolved(TypeId),
     // Should we remove this for Resolved(TypeId::void())?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,7 @@ macro_rules! jinko {
 macro_rules! jinko_fail {
     ($($tokens:tt)*) => {
         {
-            let mut ctx = $crate::context::Context::new(Box::new(crate::io_trait::JkStdReader));
+            let mut ctx = $crate::context::Context::new(Box::new($crate::io_trait::JkStdReader));
             ctx.init_stdlib().unwrap();
 
             $crate::jk_parse! (&mut ctx, $($tokens)*);
@@ -47,7 +47,7 @@ macro_rules! jinko_fail {
 macro_rules! jk_execute {
     ($($tokens:tt)*) => {
         {
-            let mut ctx = $crate::context::Context::new(Box::new(crate::io_trait::JkStdReader));
+            let mut ctx = $crate::context::Context::new(Box::new($crate::io_trait::JkStdReader));
             ctx.init_stdlib().unwrap();
 
             $crate::parser::parse(&mut ctx, stringify!($($tokens)*), None).unwrap();

--- a/src/value/jk_constant.rs
+++ b/src/value/jk_constant.rs
@@ -65,7 +65,7 @@ impl<T: Clone> JkConstant<T> {
 /// Circumvents the need for a generic implementation (see comment).
 /// Call it with the type contained in the JkConstant and the &str representation
 ///
-/// ```
+/// ```ignore
 /// // Implements a JkConstant<i64> with type displayed as "int"
 /// jk_primitive!(i64, "int");
 /// ```

--- a/stdlib/lib.jk
+++ b/stdlib/lib.jk
@@ -11,7 +11,8 @@ incl args
 incl fmt
 incl intrinsics
 
-incl vec
+/// Implicitly links with libc.so.6, this is not okay.  
+/// incl vec
 
 ext func __builtin_exit(exit_code: int);
 


### PR DESCRIPTION
As mentioned in https://github.com/jinko-core/jinko/issues/568, including the vec implementation forces a link with the `libc.so.6`, this breaks a lot of stuff, including the docker image and the usage of Jinko on machines not having the given lib.