### PR TITLE
ci: release on crates.io manually instead of using untrusted action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -52,6 +53,4 @@ jobs:
           override: true
 
       - name: "Publish jinko on crates.io"
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
Imho, we should not trust the action used to publish the crate, it is very easy for the creator to start doing some shady stuff and override the given tag so our call to his action does the shady stuff.
Also, it is even easier and shorter to publish the crate ourselves with the usual `cargo publish` command.

Do not worry about the secret, I have set it up before creating the PR. 

Also, the job was failing before the `CARGO_REGISTRY_TOKEN` was not registered in the repository secrets.

Fyi, this should fix https://github.com/jinko-core/jinko/runs/8036624585?check_suite_focus=true