### PR TITLE
Flatten: keep references to the AST throughout

### DIFF
--- a/ast-sanitizer/src/lib.rs
+++ b/ast-sanitizer/src/lib.rs
@@ -8,7 +8,7 @@ struct NoInclCtx;
 impl Visitor for NoInclCtx {
     fn visit_incl(&mut self, loc: SpanTuple, _: Symbol, _: Option<Symbol>) -> Result<Ast, Error> {
         Err(Error::new(ErrKind::Sanitizer)
-            .with_loc(Some(loc))
+            .with_loc(loc)
             .with_msg("include expression detected when none should exist".to_string()))
     }
 }
@@ -24,7 +24,7 @@ impl Visitor for OnlyWhileCtx {
     ) -> Result<Ast, Error> {
         match kind {
             LoopKind::Infinite | LoopKind::For { .. } => Err(Error::new(ErrKind::Sanitizer)
-                .with_loc(Some(location))
+                .with_loc(location)
                 .with_msg("`for` loop or `loop` loop did not get desugared correctly".to_string())),
             _ => Ok(Ast {
                 location,

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -254,6 +254,7 @@ impl Error {
         Error::new(ErrKind::Hint)
     }
 
+    // TODO: This should take an Into<String> so we can pass strings, format!(), &str...
     pub fn with_msg(self, msg: String) -> Error {
         Error {
             msg: Some(msg),
@@ -262,8 +263,16 @@ impl Error {
     }
 
     // FIXME: Should this really take an Option<Location>?
-    pub fn with_loc(self, loc: Option<SpanTuple>) -> Error {
+    #[deprecated]
+    pub fn with_opt_loc(self, loc: Option<SpanTuple>) -> Error {
         Error { loc, ..self }
+    }
+
+    pub fn with_loc(self, loc: SpanTuple) -> Error {
+        Error {
+            loc: Some(loc),
+            ..self
+        }
     }
 
     // Add a hint to emit alongside the error

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -238,6 +238,13 @@ pub struct Fir<T = ()> {
 }
 
 impl<T> Fir<T> {
+    /// Create a new and empty [`Fir`]
+    pub fn new() -> Fir<T> {
+        Fir {
+            nodes: BTreeMap::new(),
+        }
+    }
+
     /// Append a new node to the [`Fir`]
     pub fn append(self, node: Node<T>) -> Fir<T> {
         Fir {

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -205,16 +205,15 @@ impl<'ast> AstInfo<'ast> {
                 AstNode::Block { .. }
                 | AstNode::Incl { .. }
                 | AstNode::BinaryOp(_, _, _)
-                | AstNode::Function { .. }
                 | AstNode::FieldAccess(_, _)
                 | AstNode::Loop(..)
                 | AstNode::Return(..)
                 // FIXME: Is that valid?
                 | AstNode::Constant(..)
                 | AstNode::IfElse { .. }
-                | AstNode::VarAssign { .. }
                 | AstNode::Empty => None,
-                AstNode::Type { name: sym, .. }
+                AstNode::Function { decl: Declaration { name: sym, .. }, .. }
+                | AstNode::Type { name: sym, .. }
                 | AstNode::FunctionCall(Call { to: sym, .. })
                 | AstNode::TypeInstantiation(Call { to: sym, .. })
                 | AstNode::MethodCall {
@@ -223,6 +222,7 @@ impl<'ast> AstInfo<'ast> {
                     ..
                 }
                 | AstNode::VarOrEmptyType(sym)
+                | AstNode::VarAssign { to_assign: sym, .. }
                 | AstNode::VarDeclaration {
                     to_declare: sym, ..
                 } => Some(sym),

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -185,11 +185,12 @@ impl OriginExt for OriginIdx {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct FlattenData {
+#[derive(Clone, Debug)]
+pub struct FlattenData /* <'ast> */ {
     pub symbol: Option<Symbol>,
     pub location: Option<SpanTuple>, // FIXME: Remove the option
     pub scope: usize,
+    // pub ast: &'ast Ast,
 }
 
 struct Ctx {
@@ -743,7 +744,7 @@ impl Ctx {
 impl FlattenAst for ast::Ast {
     fn flatten(&self) -> Fir<FlattenData> {
         let ctx = Ctx {
-            fir: Fir::default(),
+            fir: Fir::new(),
             origin: OriginIdx::default(),
             scope: 0,
         };

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -209,6 +209,7 @@ impl<'ast> AstInfo<'ast> {
                 | AstNode::FieldAccess(_, _)
                 | AstNode::Loop(..)
                 | AstNode::Return(..)
+                // FIXME: Is that valid?
                 | AstNode::Constant(..)
                 | AstNode::IfElse { .. }
                 | AstNode::VarAssign { .. }

--- a/include_code/src/lib.rs
+++ b/include_code/src/lib.rs
@@ -48,12 +48,12 @@ fn check_base(base: &Path, location: &SpanTuple, path: &Path) -> Result<PathBuf,
             .with_msg(format!(
                 "invalid include: `{dir_candidate:?}` and `{file_candidate:?}` are both valid candidates"
             ))
-            .with_loc(Some(location.clone()))),
+            .with_loc(location.clone())),
         (false, false) => Err(Error::new(ErrKind::Context)
             .with_msg(format!(
                 "no candidate for include: `{dir_candidate:?}` and `{file_candidate:?}` do not exist"
             ))
-            .with_loc(Some(location.clone()))),
+            .with_loc(location.clone())),
         (false, true) => Ok(file_candidate),
         (true, false) => Ok(dir_candidate),
     }

--- a/interpreter/jinko.rs
+++ b/interpreter/jinko.rs
@@ -124,7 +124,8 @@ fn experimental_pipeline(input: &str, file: &Path) -> InteractResult {
     let data_fmt = |data: &FlattenData| {
         format!(
             "{} @ scope {}",
-            data.symbol
+            data.ast
+                .symbol()
                 .as_ref()
                 .map_or(String::new(), |s| format!("`{}`", Symbol::access(s))),
             data.scope

--- a/name_resolve/src/declarator.rs
+++ b/name_resolve/src/declarator.rs
@@ -5,7 +5,7 @@ use crate::{NameResolutionError, NameResolveCtx};
 
 pub(crate) struct Declarator<'ctx>(pub(crate) &'ctx mut NameResolveCtx);
 
-impl<'ctx> Traversal<FlattenData, NameResolutionError> for Declarator<'ctx> {
+impl<'ast, 'ctx> Traversal<FlattenData<'ast>, NameResolutionError> for Declarator<'ctx> {
     fn traverse_function(
         &mut self,
         _fir: &Fir<FlattenData>,
@@ -18,11 +18,11 @@ impl<'ctx> Traversal<FlattenData, NameResolutionError> for Declarator<'ctx> {
         self.0
             .mappings
             .add_function(
-                node.data.symbol.as_ref().unwrap().clone(),
+                node.data.ast.symbol().unwrap().clone(),
                 node.data.scope,
                 node.origin,
             )
-            .map_err(|ue| NameResolutionError::non_unique(&node.data.location, ue))
+            .map_err(|ue| NameResolutionError::non_unique(node.data.ast.location(), ue))
     }
 
     fn traverse_type(
@@ -35,11 +35,11 @@ impl<'ctx> Traversal<FlattenData, NameResolutionError> for Declarator<'ctx> {
         self.0
             .mappings
             .add_type(
-                node.data.symbol.as_ref().unwrap().clone(),
+                node.data.ast.symbol().unwrap().clone(),
                 node.data.scope,
                 node.origin,
             )
-            .map_err(|ue| NameResolutionError::non_unique(&node.data.location, ue))
+            .map_err(|ue| NameResolutionError::non_unique(node.data.ast.location(), ue))
     }
 
     fn traverse_binding(
@@ -51,10 +51,10 @@ impl<'ctx> Traversal<FlattenData, NameResolutionError> for Declarator<'ctx> {
         self.0
             .mappings
             .add_variable(
-                node.data.symbol.as_ref().unwrap().clone(),
+                node.data.ast.symbol().unwrap().clone(),
                 node.data.scope,
                 node.origin,
             )
-            .map_err(|ue| NameResolutionError::non_unique(&node.data.location, ue))
+            .map_err(|ue| NameResolutionError::non_unique(node.data.ast.location(), ue))
     }
 }

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -322,20 +322,7 @@ mod tests {
     use super::*;
     use fir::{Kind, RefIdx};
     use flatten::FlattenAst;
-
-    macro_rules! ast {
-        ($($tok:tt)*) => {
-            {
-                let ast = xparser::parse(
-                    stringify!($($tok)*),
-                    location::Source::Input(stringify!($($tok)*)))
-                .unwrap();
-
-                // flatten::FlattenAst::flatten(&ast)
-                ast
-            }
-        }
-    }
+    use xparser::ast;
 
     #[test]
     fn declaration() {

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -57,7 +57,7 @@ impl<'ctx> Actual<'ctx> {
     }
 }
 
-impl<'ctx> Traversal<FlattenData, Error> for Actual<'ctx> {
+impl<'ctx> Traversal<FlattenData<'_>, Error> for Actual<'ctx> {
     fn traverse_node(
         &mut self,
         fir: &Fir<FlattenData>,

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -28,7 +28,7 @@ impl<'ctx> Typer<'ctx> {
     }
 }
 
-impl Traversal<FlattenData, Error> for Typer<'_> {
+impl Traversal<FlattenData<'_>, Error> for Typer<'_> {
     fn traverse_constant(
         &mut self,
         _fir: &Fir<FlattenData>,

--- a/xparser/src/lib.rs
+++ b/xparser/src/lib.rs
@@ -97,3 +97,18 @@ impl<'i> nom::error::ParseError<ParseInput<'i>> for Error {
         Error
     }
 }
+
+/// Parse a list of token trees to a jinko [`ast::Ast`]
+#[macro_export]
+macro_rules! ast {
+        ($($tok:tt)*) => {
+            {
+                let ast = xparser::parse(
+                    stringify!($($tok)*),
+                    location::Source::Input(stringify!($($tok)*)))
+                .unwrap();
+
+                ast
+            }
+        }
+    }


### PR DESCRIPTION
The `Fir` will now be able to access AST nodes even deep in the pipeline, and to do so cheaply by just accessing a reference.

In the immediate future, this is useful for typechecking constants and accessing builtin types.

- fir: Remove Default bounds where possible
- flatten: Keep AST information in FlattenData
- flatten: Add new AstInfo enum
- ast-sanitizer: Use new Flatten API
- include_code: Use new Flatten API
- interpreter: Use new Flatten API
- error: Add new with_opt_loc function, depreciate it
- flatten: Add note about symbols from Constants
- name_resolve: Use new Flatten API
- typecheck: Use new Flatten API
- xparser: Add new ast!() macro
- name_resolve: Use xparser::ast! macro
- flatten: Fix AstInfo::symbol in some cases
- rec_typecheck: Use new Flatten API
