### PR TITLE
typecheck: Allow proper typechecking of primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "typecheck"
 version = "0.1.0"
 dependencies = [
+ "ast",
  "colored",
  "error",
  "fir",

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -62,7 +62,7 @@ impl<T: Debug> Fir<T> {
                 // FIXME: This is missing a bunch of valid "checks". For example, checking that a call's argument can
                 // point to an if-else expression. Basically, to anything that's an expression actually.
                 // Should we split the fir::Kind into fir::Kind::Stmt and fir::Kind::Expr? Or does that not make sense?
-                Kind::Constant(r) => check!(r => Kind::TypeReference(_), node),
+                Kind::Constant(r) => check!(r => Kind::Type { .. }, node),
                 Kind::TypedValue { value, ty } => {
                     // FIXME: Is pointing to `Type` here valid?
                     check!(ty => Kind::Type { .. } | Kind::TypeReference(_), node);

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -230,6 +230,22 @@ impl<'ast> AstInfo<'ast> {
             AstInfo::Helper(symbol, _) => Some(symbol),
         }
     }
+
+    /// Fetch the [`AstInfo::Node`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is actually an [`AstInfo::Helper`]
+    pub fn node(&self) -> &Ast {
+        match self {
+            AstInfo::Node(node) => node,
+            AstInfo::Helper(_, _) => unreachable!("asked for AST node from an `AstInfo::Helper`"),
+        }
+    }
+
+    /// Fetch the [`AstInfo::Helper`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is actually an [`AstInfo::Node`]
+    pub fn helper(&self) -> (&Symbol, &SpanTuple) {
+        match self {
+            AstInfo::Helper(sym, loc) => (sym, loc),
+            AstInfo::Node(_) => unreachable!("asked for Helper from an `AstInfo::Node`"),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/typecheck/Cargo.toml
+++ b/typecheck/Cargo.toml
@@ -12,6 +12,7 @@ flatten = { path = "../flatten" }
 error = { path = "../error" }
 symbol = { path = "../symbol" }
 location = { path = "../location" }
+ast = { path = "../ast" }
 
 [dev-dependencies]
 xparser = { path = "../xparser" }

--- a/typecheck/src/lib.rs
+++ b/typecheck/src/lib.rs
@@ -1,5 +1,6 @@
 mod actual;
 mod checker;
+mod primitives;
 mod typer;
 
 use std::collections::HashMap;
@@ -12,13 +13,16 @@ use actual::Actual;
 use checker::Checker;
 use typer::Typer;
 
+use primitives::PrimitiveTypes;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Type {
     One(RefIdx),
 }
 
-#[derive(Default)]
 pub(crate) struct TypeCtx {
+    // primitive type declaration
+    pub(crate) primitives: PrimitiveTypes,
     // mapping from declaration to type
     pub(crate) types: HashMap<OriginIdx, Option<Type>>,
 }
@@ -29,7 +33,13 @@ pub trait TypeCheck<T>: Sized {
 
 impl<'ast> TypeCheck<Fir<FlattenData<'ast>>> for Fir<FlattenData<'ast>> {
     fn type_check(self) -> Result<Fir<FlattenData<'ast>>, Error> {
-        TypeCtx::default().pass(self)
+        let primitives = primitives::find(&self)?;
+
+        TypeCtx {
+            primitives,
+            types: HashMap::new(),
+        }
+        .pass(self)
     }
 }
 

--- a/typecheck/src/primitives.rs
+++ b/typecheck/src/primitives.rs
@@ -1,0 +1,224 @@
+//! First, we need to fetch the primitive types from the current source, and error out if
+//! they are not present. This module uses typestates to ensure that we only provide a valid
+//! set of primitives, or return an error
+
+use error::{ErrKind, Error};
+use fir::{Fallible, Fir, Node, OriginIdx, RefIdx, Traversal};
+use flatten::FlattenData;
+use location::SpanTuple;
+use symbol::Symbol;
+
+/// All primitive types that must be found before we actually perform typechecking
+#[derive(Default)]
+struct PrimitiveTypeCtx {
+    bool_type: Option<OriginIdx>,
+    char_type: Option<OriginIdx>,
+    int_type: Option<OriginIdx>,
+    float_type: Option<OriginIdx>,
+    string_type: Option<OriginIdx>,
+}
+
+/// This is the finalized version of [`PrimitiveTypeCtx`] - a version which only has
+/// valid [`OriginIdx`], or otherwise it will not be returned, and an [`Error`] will
+/// be present instead
+pub struct PrimitiveTypes {
+    pub(crate) bool_type: OriginIdx,
+    pub(crate) char_type: OriginIdx,
+    pub(crate) int_type: OriginIdx,
+    pub(crate) float_type: OriginIdx,
+    pub(crate) string_type: OriginIdx,
+}
+
+fn validate_type(
+    fir: &Fir<FlattenData<'_>>,
+    sym: &Symbol,
+    loc: &SpanTuple,
+    generics: &[RefIdx],
+    fields: &[RefIdx],
+) -> Fallible<Error> {
+    let collect_locs = |many_refs: &[RefIdx]| {
+        many_refs
+            .iter()
+            .map(|generic| &fir.nodes[&generic.unwrap()])
+            .map(|node| node.data.ast.location().clone())
+            .collect::<Vec<SpanTuple>>()
+    };
+
+    let maybe_err = |many_refs: &[RefIdx], kind: &str, to_remove: &str| {
+        (!many_refs.is_empty()).then_some({
+            let err = Error::new(ErrKind::TypeChecker)
+                .with_msg(format!("primitive type `{sym}` was declared with {kind}"))
+                .with_loc(loc.clone());
+
+            let locs = collect_locs(generics);
+
+            locs.into_iter().fold(err, |err, loc| {
+                err.with_hint(
+                    Error::hint()
+                        .with_msg(format!("remove this {to_remove}"))
+                        .with_loc(loc),
+                )
+            })
+        })
+    };
+
+    let generic_error = maybe_err(generics, "generics", "generic parameter");
+    let field_error = maybe_err(fields, "fields", "field");
+
+    match (generic_error, field_error) {
+        (None, None) => Ok(()),
+        (Some(e1), Some(e2)) => Err(Error::new(ErrKind::Multiple(vec![e1, e2]))),
+        (Some(e), _) | (_, Some(e)) => Err(e),
+    }
+}
+
+fn duplicate(fir: &Fir<FlattenData<'_>>, old: &OriginIdx, new: &OriginIdx) -> Error {
+    let old = &fir.nodes[old].data.ast;
+
+    let name = old.symbol().unwrap();
+    let old_loc = old.location().clone();
+    let new_loc = fir.nodes[new].data.ast.location().clone();
+
+    Error::new(ErrKind::TypeChecker)
+        .with_msg(format!("re-declaration of primitive type {name}"))
+        .with_hint(
+            Error::hint()
+                .with_msg(format!("primitive type {name} previously declared here"))
+                .with_loc(old_loc),
+        )
+        .with_hint(Error::hint().with_msg(String::from(
+            "re-defining primitive types in a different scope is not allowed",
+        )))
+        .with_loc(new_loc)
+}
+
+impl Traversal<FlattenData<'_>, Error> for PrimitiveTypeCtx {
+    fn traverse_type(
+        &mut self,
+        fir: &Fir<FlattenData<'_>>,
+        node: &Node<FlattenData<'_>>,
+        generics: &[RefIdx],
+        fields: &[RefIdx],
+    ) -> Fallible<Error> {
+        let ast = &node.data.ast;
+        // Type declarations always have a symbol, we can unwrap safely, or this is an
+        // interpreter error
+        let name = ast.symbol().unwrap();
+
+        let field_to_set = match name.access() {
+            "bool" => Some(&mut self.bool_type),
+            "char" => Some(&mut self.char_type),
+            "int" => Some(&mut self.int_type),
+            "float" => Some(&mut self.float_type),
+            "string" => Some(&mut self.string_type),
+            _ => None,
+        };
+
+        if let Some(field) = field_to_set {
+            validate_type(fir, name, ast.location(), generics, fields)?;
+
+            if let Some(existing) = *field {
+                Err(duplicate(fir, &existing, &node.origin))
+            } else {
+                *field = Some(node.origin);
+
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn extract_types(ctx: &PrimitiveTypeCtx) -> Result<PrimitiveTypes, Error> {
+    let missing_ty = |name| {
+        move || {
+            Error::new(ErrKind::TypeChecker).with_msg(format!(
+                "missing implementation for primitive type `{name}`",
+            ))
+        }
+    };
+
+    // FIXME: we need to do a fold here and accumulate errors
+    let bool_type = ctx.bool_type.ok_or_else(missing_ty("bool"))?;
+    let char_type = ctx.char_type.ok_or_else(missing_ty("char"))?;
+    let int_type = ctx.int_type.ok_or_else(missing_ty("int"))?;
+    let float_type = ctx.float_type.ok_or_else(missing_ty("float"))?;
+    let string_type = ctx.string_type.ok_or_else(missing_ty("string"))?;
+
+    Ok(PrimitiveTypes {
+        bool_type,
+        char_type,
+        int_type,
+        float_type,
+        string_type,
+    })
+}
+
+pub fn find(fir: &Fir<FlattenData<'_>>) -> Result<PrimitiveTypes, Error> {
+    let mut ctx = PrimitiveTypeCtx::default();
+
+    ctx.traverse(fir)?;
+
+    extract_types(&ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use flatten::FlattenAst;
+    use name_resolve::NameResolve;
+    use xparser::ast;
+
+    #[test]
+    fn full_decls() {
+        let ast = ast! {
+            type true;
+            type false;
+            type bool;
+
+            type char;
+            type int;
+            type float;
+
+            type string;
+        };
+
+        let fir = ast.flatten().name_resolve().unwrap();
+
+        assert!(super::find(&fir).is_ok())
+    }
+
+    #[test]
+    fn missing_ty() {
+        let ast = ast! {
+            type true;
+            type false;
+            type bool;
+
+            type string;
+        };
+
+        let fir = ast.flatten().name_resolve().unwrap();
+
+        assert!(super::find(&fir).is_err())
+    }
+
+    #[test]
+    fn invalid_declaration() {
+        let ast = ast! {
+            type true;
+            type false;
+            type bool;
+
+            type char;
+            type int;
+            type float;
+
+            type string(data: char, next: char, size: int);
+        };
+
+        let fir = ast.flatten().name_resolve().unwrap();
+
+        assert!(super::find(&fir).is_err())
+    }
+}

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -1,6 +1,7 @@
+use ast::{Node as AstNode, Value};
 use error::Error;
 use fir::{Fallible, Fir, Node, RefIdx, Traversal};
-use flatten::FlattenData;
+use flatten::{AstInfo, FlattenData};
 
 use crate::{Type, TypeCtx};
 
@@ -35,6 +36,17 @@ impl Traversal<FlattenData<'_>, Error> for Typer<'_> {
         node: &Node<FlattenData>,
         _constant: &RefIdx,
     ) -> Fallible<Error> {
+        let ast = node.data.ast.node();
+
+        match &ast.node {
+            AstNode::Constant(Value::Bool(value)) => {}
+            AstNode::Constant(Value::Char(value)) => {}
+            AstNode::Constant(Value::Integer(value)) => {}
+            AstNode::Constant(Value::Float(value)) => {}
+            AstNode::Constant(Value::Str(value)) => {}
+            _ => unreachable!(),
+        }
+
         // switch on the constant's kind - and this is a *declare* spot, so we must use
         // TypeData::from(data).declares(ty). This way, things like blocks returning constants can simply
         // depend on the type returned by the constant.


### PR DESCRIPTION
This now allows the typechecker to recognize our primtive types and resolve the type of constants/literals.