### PR TITLE
Fix function binding name resolution

### DIFF
--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -95,9 +95,9 @@
 // Does that make sense? Does that indicate that for all types we must first keep a Option<Ty> which is set to None?
 // Is this going to cause problems?
 
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::{collections::BTreeMap, ops::Index};
 
 mod checks;
 pub mod iter;
@@ -221,6 +221,14 @@ pub enum Kind {
     },
     Statements(Vec<RefIdx>), // to any kind
     Return(Option<RefIdx>),  // to any kind
+}
+
+impl<T> Index<&RefIdx> for Fir<T> {
+    type Output = Node<T>;
+
+    fn index(&self, index: &RefIdx) -> &Node<T> {
+        &self.nodes[&index.unwrap()]
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -122,7 +122,7 @@ pub enum RefIdx {
 
 impl RefIdx {
     #[track_caller]
-    pub fn unwrap(&self) -> OriginIdx {
+    pub fn expect_resolved(&self) -> OriginIdx {
         match self {
             RefIdx::Resolved(idx) => *idx,
             RefIdx::Unresolved => unreachable!("unexpected `RefIdx::Unresolved` in `Fir`"),
@@ -227,7 +227,15 @@ impl<T> Index<&RefIdx> for Fir<T> {
     type Output = Node<T>;
 
     fn index(&self, index: &RefIdx) -> &Node<T> {
-        &self.nodes[&index.unwrap()]
+        &self.nodes[&index.expect_resolved()]
+    }
+}
+
+impl<T> Index<&OriginIdx> for Fir<T> {
+    type Output = Node<T>;
+
+    fn index(&self, index: &OriginIdx) -> &Node<T> {
+        &self.nodes[index]
     }
 }
 

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -690,7 +690,7 @@ impl<'ast> Ctx<'ast> {
     fn visit_var_declaration(
         self,
         ast: AstInfo<'ast>,
-        _mutable: &bool,
+        _mutable: bool,
         _to_declare: &Symbol,
         value: &'ast Ast,
     ) -> (Ctx<'ast>, RefIdx) {
@@ -802,7 +802,7 @@ impl<'ast> Ctx<'ast> {
                 mutable,
                 to_declare,
                 value,
-            } => self.visit_var_declaration(node, mutable, to_declare, value),
+            } => self.visit_var_declaration(node, *mutable, to_declare, value),
             AstNode::VarAssign { to_assign, value } => {
                 self.visit_var_assign(node, to_assign, value)
             }
@@ -899,7 +899,7 @@ mod tests {
             Kind::Statements(stmts) => stmts,
             _ => unreachable!(),
         };
-        let ret_idx = stmts[0].unwrap();
+        let ret_idx = stmts[0].expect_resolved();
 
         assert!(matches!(
             fir.nodes.get(&ret_idx).unwrap().kind,

--- a/name_resolve/src/declarator.rs
+++ b/name_resolve/src/declarator.rs
@@ -1,80 +1,78 @@
-use fir::{Fallible, Fir, Node, RefIdx, Traversal};
+use fir::{Fallible, Fir, Node, OriginIdx, RefIdx, Traversal};
 use flatten::FlattenData;
 
 use crate::{NameResolutionError, NameResolveCtx, UniqueError};
 
+enum DefinitionKind {
+    Function,
+    Type,
+    Binding,
+}
+
 pub(crate) struct Declarator<'ctx, 'enclosing>(pub(crate) &'ctx mut NameResolveCtx<'enclosing>);
+
+impl<'ctx, 'enclosing> Declarator<'ctx, 'enclosing> {
+    fn define(
+        &mut self,
+        kind: DefinitionKind,
+        node: &Node<FlattenData>,
+    ) -> Fallible<NameResolutionError> {
+        let (map, kind) = match kind {
+            DefinitionKind::Function => (&mut self.0.mappings.functions, "function"),
+            DefinitionKind::Type => (&mut self.0.mappings.types, "type"),
+            DefinitionKind::Binding => (&mut self.0.mappings.bindings, "binding"),
+        };
+
+        map.insert(
+            node.data.ast.symbol().unwrap().clone(),
+            node.origin,
+            self.0.enclosing_scope[node.origin],
+        )
+        .map_err(|existing| Declarator::unique_error(node, existing, kind))
+    }
+
+    fn unique_error(
+        node: &Node<FlattenData>,
+        existing: OriginIdx,
+        kind: &'static str,
+    ) -> NameResolutionError {
+        NameResolutionError::non_unique(node.data.ast.location(), UniqueError(existing, kind))
+    }
+}
 
 impl<'ast, 'ctx, 'enclosing> Traversal<FlattenData<'ast>, NameResolutionError>
     for Declarator<'ctx, 'enclosing>
 {
+    // TODO: Can we factor these three functions?
+
     fn traverse_function(
         &mut self,
-        _fir: &Fir<FlattenData>,
+        _: &Fir<FlattenData>,
         node: &Node<FlattenData>,
-        _generics: &[RefIdx],
-        _args: &[RefIdx],
-        _return_ty: &Option<RefIdx>,
-        _block: &Option<RefIdx>,
+        _: &[RefIdx],
+        _: &[RefIdx],
+        _: &Option<RefIdx>,
+        _: &Option<RefIdx>,
     ) -> Fallible<NameResolutionError> {
-        self.0
-            .mappings
-            .functions
-            .insert(
-                node.data.ast.symbol().unwrap().clone(),
-                node.origin,
-                self.0.enclosing_scope[node.origin],
-            )
-            .map_err(|existing| {
-                NameResolutionError::non_unique(
-                    node.data.ast.location(),
-                    UniqueError(existing, "function"),
-                )
-            })
+        self.define(DefinitionKind::Function, node)
     }
 
     fn traverse_type(
         &mut self,
-        _fir: &Fir<FlattenData>,
+        _: &Fir<FlattenData>,
         node: &Node<FlattenData>,
         _: &[RefIdx],
         _: &[RefIdx],
     ) -> Fallible<NameResolutionError> {
-        self.0
-            .mappings
-            .types
-            .insert(
-                node.data.ast.symbol().unwrap().clone(),
-                node.origin,
-                self.0.enclosing_scope[node.origin],
-            )
-            .map_err(|existing| {
-                NameResolutionError::non_unique(
-                    node.data.ast.location(),
-                    UniqueError(existing, "type"),
-                )
-            })
+        self.define(DefinitionKind::Type, node)
     }
 
     fn traverse_binding(
         &mut self,
-        _fir: &Fir<FlattenData>,
+        _: &Fir<FlattenData>,
         node: &Node<FlattenData>,
-        _to: &RefIdx,
+        _: &RefIdx,
     ) -> Fallible<NameResolutionError> {
-        self.0
-            .mappings
-            .variables
-            .insert(
-                node.data.ast.symbol().unwrap().clone(),
-                node.origin,
-                self.0.enclosing_scope[node.origin],
-            )
-            .map_err(|existing| {
-                NameResolutionError::non_unique(
-                    node.data.ast.location(),
-                    UniqueError(existing, "binding"),
-                )
-            })
+        self.define(DefinitionKind::Binding, node)
     }
 }

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -1,3 +1,40 @@
+//! The name-resolve module takes care of resolving each "name" within a `jinko` program to
+//! its definition site. You can think of it as a function, which will take an unresolved
+//! [`Fir`] as input, and output a new [`Fir`] where each node points to the definition it
+//! uses. To do this, multiple passes are applied on the input [`Fir`].
+//!
+//! 1. We start by "scoping" *all* of the definitions and usages in the program.
+//! This is done via the [`Scoper`] type, which will assign an enclosing scope to
+//! each node of our [`Fir`]. This is important, since name resolution in `jinko`
+//! can go "backwards" or "upwards". You can access a definition in an *outer*
+//! scope from an *inner* scope. This means that the outermost scope is able to
+//! use definitions from the outermost scope. But if this "enclosing" or "parent"
+//! relationship does not exist, then the usage is invalid:
+//!
+//! ```ignore
+//! {
+//!     func foo() {}
+//! }
+//! {
+//!     { foo() }
+//!     // this scope does not have `foo`'s scope as a parent, so it will need to error out later on
+//! }
+//! ```
+//!
+//! 2. We collect all of the definitions within the program using the [`Declarator`] struct.
+//! A definition can be a function definition, a new type, as well as a new binding. This
+//! "definition collection" pass will only error out if a definition is present twice, e.g.:
+//!
+//! ```ignore
+//! func foo() {}
+//! func foo(different: int, arguments: int) -> string { "oh no" }
+//! ```
+//!
+//! 2. Finally, we resolve all *usages* to their *definitions* using the [`Resolver`] type.
+//! If a usage cannot be resolved to a definition, then it is an error. Similarly, if a usage
+//! can be resolved to more than one definitions, we error out. The resolver does not take care
+//! of resolving complex usages, such as methods, generic function calls or specialization.
+
 use std::{collections::HashMap, ops::Index};
 
 use error::{ErrKind, Error};
@@ -273,7 +310,7 @@ impl<'enclosing> NameResolveCtx<'enclosing> {
         let root = fir.nodes.last_key_value().unwrap();
 
         let mut scoper = Scoper {
-            current_scope: *root.0,
+            current_scope: scoper::Scope(*root.0),
             enclosing_scope: HashMap::new(),
         };
 

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -97,10 +97,7 @@ impl<'enclosing> FlatScope<'enclosing> {
             return Err(*existing);
         }
 
-        self.scopes
-            .entry(scope)
-            .or_insert_with(HashMap::new)
-            .insert(name, idx);
+        self.scopes.entry(scope).or_default().insert(name, idx);
 
         Ok(())
     }
@@ -230,12 +227,14 @@ impl NameResolutionError {
                 // TODO: Go through mappings again to find a relevant type or var which could work
 
                 Error::new(ErrKind::NameResolution)
-                    .with_msg(format!("unresolved binding to {sym}"))
+                    .with_msg(format!("unresolved binding to `{sym}`"))
                     .with_loc(location)
                     .with_hint(
-                        Error::hint().with_msg(format!("searched for empty type named {sym}")),
+                        Error::hint().with_msg(format!("searched for empty type named `{sym}`")),
                     )
-                    .with_hint(Error::hint().with_msg(format!("searched for binding named {sym}")))
+                    .with_hint(
+                        Error::hint().with_msg(format!("searched for binding named `{sym}`")),
+                    )
             }
         }
     }
@@ -278,7 +277,9 @@ impl<'enclosing> NameResolveCtx<'enclosing> {
             enclosing_scope: HashMap::new(),
         };
 
-        let Kind::Statements(stmts) = &root.1.kind else { unreachable!() };
+        let Kind::Statements(stmts) = &root.1.kind else {
+            unreachable!()
+        };
 
         stmts
             .iter()
@@ -364,7 +365,12 @@ mod tests {
         let a_reference = &fir.nodes[&OriginIdx(3)];
 
         assert!(matches!(a_reference.kind, Kind::TypedValue { .. }));
-        let Kind::TypedValue { value: a_reference, .. } = a_reference.kind else { unreachable!() };
+        let Kind::TypedValue {
+            value: a_reference, ..
+        } = a_reference.kind
+        else {
+            unreachable!()
+        };
 
         assert_eq!(a_reference, RefIdx::Resolved(a.origin));
     }

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -44,7 +44,7 @@ impl<'ctx, 'enclosing> Resolver<'ctx, 'enclosing> {
         let origin = match kind {
             ResolveKind::Call => mappings.functions.lookup(symbol, scope),
             ResolveKind::Type => mappings.types.lookup(symbol, scope),
-            ResolveKind::Var => mappings.variables.lookup(symbol, scope),
+            ResolveKind::Var => mappings.bindings.lookup(symbol, scope),
         };
 
         origin.map_or_else(

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -38,7 +38,9 @@ impl<'ctx, 'enclosing> Resolver<'ctx, 'enclosing> {
             sym.expect("attempting to get definition for non existent symbol - interpreter bug");
 
         let mappings = &self.0.mappings;
+
         let scope = self.0.enclosing_scope[dbg!(node)];
+
         let origin = match kind {
             ResolveKind::Call => mappings.functions.lookup(symbol, scope),
             ResolveKind::Type => mappings.types.lookup(symbol, scope),
@@ -120,7 +122,6 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         };
 
         let definition = match (var_def, ty_def) {
-            (Ok(def), Err(_)) | (Err(_), Ok(def)) => Ok(def),
             (Ok(var_def), Ok(ty_def)) => Err(NameResolutionError::ambiguous_binding(
                 var_def,
                 ty_def,
@@ -130,6 +131,7 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
                 data.ast.symbol(),
                 data.ast.location(),
             )),
+            (Ok(def), _) | (_, Ok(def)) => Ok(def),
         }?;
 
         Ok(Node {

--- a/name_resolve/src/scoper.rs
+++ b/name_resolve/src/scoper.rs
@@ -1,0 +1,143 @@
+// pub trait Scoper {
+
+// }
+
+use std::collections::HashMap;
+
+use fir::{Fallible, Fir, Kind, Node, OriginIdx, RefIdx, Traversal};
+use flatten::FlattenData;
+
+pub(crate) struct Scoper {
+    pub(crate) current_scope: RefIdx,
+    pub(crate) enclosing_scope: HashMap<OriginIdx, RefIdx>,
+}
+
+impl Scoper {
+    /// Set the enclosing scope of `to_scope` to the current scope
+    fn scope(&mut self, to_scope: &Node<FlattenData>) {
+        self.enclosing_scope
+            .insert(to_scope.origin, self.current_scope);
+    }
+}
+
+impl<'ast> Traversal<FlattenData<'ast>, () /* FIXME: Ok? */> for Scoper {
+    fn traverse_function(
+        &mut self,
+        fir: &Fir<FlattenData<'ast>>,
+        _node: &Node<FlattenData<'ast>>,
+        generics: &[RefIdx],
+        args: &[RefIdx],
+        return_ty: &Option<RefIdx>,
+        block: &Option<RefIdx>,
+    ) -> Fallible<()> {
+        let old_scope = self.current_scope;
+
+        generics
+            .iter()
+            .for_each(|generic| self.traverse_node(fir, &fir[generic]).unwrap());
+
+        args.iter()
+            .for_each(|arg| self.traverse_node(fir, &fir[arg]).unwrap());
+
+        block.map(|definition| self.traverse_node(fir, &fir[&definition]));
+        return_ty.map(|ty| self.traverse_node(fir, &fir[&ty]));
+
+        self.current_scope = old_scope;
+
+        Ok(())
+    }
+
+    fn traverse_statements(
+        &mut self,
+        fir: &Fir<FlattenData<'ast>>,
+        node: &Node<FlattenData<'ast>>,
+        stmts: &[RefIdx],
+    ) -> Fallible<()> {
+        let old_scope = self.current_scope;
+        self.current_scope = RefIdx::Resolved(node.origin);
+
+        stmts
+            .iter()
+            // this is safe since the Scoper will never throw an error // FIXME: Is that true?
+            .for_each(|stmt| self.traverse_node(fir, &fir[stmt]).unwrap());
+
+        self.current_scope = old_scope;
+
+        Ok(())
+    }
+
+    fn traverse_node(
+        &mut self,
+        fir: &Fir<FlattenData<'ast>>,
+        node: &Node<FlattenData<'ast>>,
+    ) -> Fallible<()> {
+        self.scope(node);
+
+        match &node.kind {
+            Kind::Constant(sub_node)
+            | Kind::TypeReference(sub_node)
+            | Kind::TypedValue {
+                value: sub_node, ..
+            }
+            | Kind::Instantiation { to: sub_node, .. }
+            | Kind::TypeOffset {
+                instance: sub_node, ..
+            }
+            | Kind::Binding { to: sub_node } => self.traverse_node(fir, &fir[sub_node]),
+            Kind::Type { fields, .. } => {
+                fields
+                    .iter()
+                    .for_each(|field| self.traverse_node(fir, &fir[field]).unwrap());
+
+                Ok(())
+            }
+            Kind::Generic { default } => default
+                .map(|def| self.traverse_node(fir, &fir[&def]))
+                .ok_or(())?,
+            Kind::Assignment { to, from } => self.traverse_assignment(fir, node, to, from),
+            Kind::Call { to, generics, args } => {
+                self.traverse_node(fir, &fir[to])?;
+                generics
+                    .iter()
+                    .for_each(|generic| self.traverse_node(fir, &fir[generic]).unwrap());
+                args.iter()
+                    .for_each(|arg| self.traverse_node(fir, &fir[arg]).unwrap());
+
+                Ok(())
+            }
+            Kind::Function {
+                generics,
+                args,
+                return_type,
+                block,
+            } => self.traverse_function(fir, node, generics, args, return_type, block),
+            Kind::Statements(stmts) => self.traverse_statements(fir, node, stmts),
+            Kind::Conditional {
+                condition,
+                true_block,
+                false_block,
+            } => {
+                self.traverse_node(fir, &fir[condition])?;
+                self.traverse_node(fir, &fir[true_block])?;
+                false_block
+                    .map(|else_block| self.traverse_node(fir, &fir[&else_block]))
+                    .ok_or(())?
+            }
+            Kind::Return(sub_node) => sub_node
+                .map(|node| self.traverse_node(fir, &fir[&node]))
+                .ok_or(())?,
+            Kind::Loop { condition, block } => {
+                self.traverse_node(fir, &fir[condition])?;
+                self.traverse_node(fir, &fir[block])?;
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Nothing to do here, right? This function should never be called
+    /// FIXME: Add documentation
+    fn traverse(&mut self, _fir: &Fir<FlattenData<'ast>>) -> Fallible<Vec<()>> {
+        unreachable!()
+    }
+}

--- a/name_resolve/src/scoper.rs
+++ b/name_resolve/src/scoper.rs
@@ -44,6 +44,17 @@ impl Scoper {
 }
 
 impl<'ast> Traversal<FlattenData<'ast>, () /* FIXME: Ok? */> for Scoper {
+    fn traverse_assignment(
+        &mut self,
+        fir: &Fir<FlattenData<'ast>>,
+        _node: &Node<FlattenData<'ast>>,
+        to: &RefIdx,
+        from: &RefIdx,
+    ) -> Fallible<()> {
+        self.maybe_visit_child(fir, to)?;
+        self.maybe_visit_child(fir, from)
+    }
+
     fn traverse_function(
         &mut self,
         fir: &Fir<FlattenData<'ast>>,

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -10,7 +10,7 @@ use crate::{Type, TypeCtx};
 pub(crate) struct Actual<'ctx>(pub(crate) &'ctx mut TypeCtx);
 
 fn innermost_type(fir: &Fir<FlattenData>, linked_node: RefIdx) -> Option<Type> {
-    let linked_node = &fir.nodes[&linked_node.unwrap()];
+    let linked_node = &fir.nodes[&linked_node.expect_resolved()];
 
     let inner_opt = |fir, opt| match opt {
         Some(opt) => innermost_type(fir, opt),

--- a/typecheck/src/checker.rs
+++ b/typecheck/src/checker.rs
@@ -20,7 +20,7 @@ impl<'ctx> Checker<'ctx> {
     fn get_type(&self, of: &RefIdx) -> Option<Type> {
         // if at this point, the reference is unresolved, or if we haven't seen that node yet, it's
         // an interpreter error
-        *self.0.types.get(&of.unwrap()).unwrap()
+        *self.0.types.get(&of.expect_resolved()).unwrap()
     }
 }
 
@@ -32,7 +32,7 @@ fn type_mismatch(
 ) -> Error {
     let get_symbol = |ty| {
         let Type::One(idx) = ty;
-        fir.nodes[&idx.unwrap()].data.ast.symbol().unwrap()
+        fir.nodes[&idx.expect_resolved()].data.ast.symbol().unwrap()
     };
     let name_fmt = |ty: Option<&Symbol>| match ty {
         Some(ty) => format!("`{}`", ty.access().purple()),

--- a/typecheck/src/primitives.rs
+++ b/typecheck/src/primitives.rs
@@ -39,7 +39,7 @@ fn validate_type(
     let collect_locs = |many_refs: &[RefIdx]| {
         many_refs
             .iter()
-            .map(|generic| &fir.nodes[&generic.unwrap()])
+            .map(|generic| &fir.nodes[&generic.expect_resolved()])
             .map(|node| node.data.ast.location().clone())
             .collect::<Vec<SpanTuple>>()
     };


### PR DESCRIPTION
- name-resolve: Add `Scoper` pass
- fir: Allowing index through Fir with RefIdx
- fir: Allow indexing with RefIdx, rename `RefIdx::unwrap`
- [f] name_resolve: Add base for new scope maps and algorithms
