### PR TITLE
Name resolve multi types

### DIFF
--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -28,6 +28,7 @@ pub enum TypeKind {
 /// func apply_fn(arg: int, fn: func(int) -> int) -> int { fn(arg) }
 /// ```
 #[derive(Debug, Clone)]
+// TODO: Rename? `Type`?
 pub struct TypeArgument {
     pub kind: TypeKind,
     // the generics and location are common fields between the multiple kinds, so they are lifted out of the `TypeKind` enum

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -36,6 +36,21 @@ pub struct TypeArgument {
     pub generics: Vec<TypeArgument>,
 }
 
+/// The fields of a type declaration. This data structure helps differentiating record types, from
+/// tuple types, from type aliases, from empty types
+#[derive(Debug, Clone)]
+pub enum TypeFields {
+    /// An empty type: `type Foo;`
+    None,
+    /// A record type: `type Foo(field1: Bar, field2: Baz);`
+    Record(Vec<TypedValue>),
+    /// A named tuple, or tuple type: `type Foo(Bar, Baz);`
+    Tuple(Vec<TypeArgument>),
+    /// A type alias: `type Foo = Bar;`
+    /// This can be an alias to a multi type - a single [`TypeArgument`] of kind [`TypeKind::Multi`]
+    Alias(TypeArgument),
+}
+
 /// A value with its associated type. This is used for function arguments or type fields
 // FIXME: This needs a location right?
 #[derive(Debug, Clone)]
@@ -141,7 +156,7 @@ pub enum Node {
     Type {
         name: Symbol,
         generics: Vec<GenericArgument>,
-        fields: Vec<TypedValue>,
+        fields: TypeFields,
         with: Option<Box<Ast>>,
     },
     TypeInstantiation(Call),
@@ -263,7 +278,7 @@ pub trait Visitor {
         location: SpanTuple,
         name: Symbol,
         generics: Vec<GenericArgument>,
-        fields: Vec<TypedValue>,
+        fields: TypeFields,
         with: Option<Box<Ast>>,
     ) -> Result<Ast, Error> {
         let with = self.optional(with, Self::boxed)?;

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -28,7 +28,6 @@ pub enum TypeKind {
 /// func apply_fn(arg: int, fn: func(int) -> int) -> int { fn(arg) }
 /// ```
 #[derive(Debug, Clone)]
-// TODO: Rename? `Type`?
 pub struct Type {
     pub kind: TypeKind,
     /// the generics and location are common fields between the multiple kinds, so they are lifted out of the [`TypeKind`] enum
@@ -41,7 +40,7 @@ pub struct Type {
 /// tuple types, from type aliases, from empty types
 // TODO: How does this handle sum types?
 #[derive(Debug, Clone)]
-pub enum TypeFields {
+pub enum TypeContent {
     // TODO: Merge with `Record`?
     /// An empty type: `type Foo;`
     None,
@@ -158,7 +157,7 @@ pub enum Node {
     Type {
         name: Symbol,
         generics: Vec<GenericParameter>,
-        fields: TypeFields,
+        fields: TypeContent,
         with: Option<Box<Ast>>,
     },
     TypeInstantiation(Call),
@@ -280,7 +279,7 @@ pub trait Visitor {
         location: SpanTuple,
         name: Symbol,
         generics: Vec<GenericParameter>,
-        fields: TypeFields,
+        fields: TypeContent,
         with: Option<Box<Ast>>,
     ) -> Result<Ast, Error> {
         let with = self.optional(with, Self::boxed)?;

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -6,7 +6,11 @@ use symbol::Symbol;
 
 #[derive(Debug, Clone)]
 pub enum TypeKind {
-    Ty(Symbol),
+    // TODO: Should we consider a simple type as a variant of multi type with only one type argument?
+    // probably simpler, right?
+    // but then how do we handle a simple type like "int" without generics or anything
+    Simple(Symbol),
+    Multi(Vec<TypeArgument>),
     FunctionLike(Vec<TypeArgument>, Option<Box<TypeArgument>>),
 }
 
@@ -16,6 +20,7 @@ pub enum TypeKind {
 /// a: int = id<int>(15);
 ///
 /// a: int = 15;
+/// a: int | string = if true { "jinko" } else { 14 };
 ///
 /// func f(arg: Vector<int>) {}
 /// func g(arg: Tuple<int, float>) {}
@@ -24,9 +29,10 @@ pub enum TypeKind {
 /// ```
 #[derive(Debug, Clone)]
 pub struct TypeArgument {
+    pub kind: TypeKind,
+    // the generics and location are common fields between the multiple kinds, so they are lifted out of the `TypeKind` enum
     pub location: SpanTuple,
     pub generics: Vec<TypeArgument>,
-    pub kind: TypeKind,
 }
 
 /// A value with its associated type. This is used for function arguments or type fields

--- a/builtins/src/builder.rs
+++ b/builtins/src/builder.rs
@@ -2,11 +2,11 @@
 
 use crate::BuiltinType;
 
-use ast::{Ast, Declaration, FunctionKind, Node, TypeArgument, TypeKind, TypedValue};
+use ast::{Ast, Declaration, FunctionKind, Node, Type, TypeFields, TypeKind, TypedValue};
 use location::SpanTuple;
 use symbol::Symbol;
 
-pub fn argument(name: &str, ty: TypeArgument) -> TypedValue {
+pub fn argument(name: &str, ty: Type) -> TypedValue {
     TypedValue {
         location: SpanTuple::builtin(),
         symbol: Symbol::from(name),
@@ -14,11 +14,11 @@ pub fn argument(name: &str, ty: TypeArgument) -> TypedValue {
     }
 }
 
-pub fn ty_arg(ty: BuiltinType) -> TypeArgument {
-    TypeArgument {
+pub fn ty_arg(ty: BuiltinType) -> Type {
+    Type {
         location: SpanTuple::builtin(),
         generics: vec![],
-        kind: TypeKind::Ty(Symbol::from(ty.name())),
+        kind: TypeKind::Simple(Symbol::from(ty.name())),
     }
 }
 
@@ -28,13 +28,13 @@ pub fn ty(ty: BuiltinType) -> Ast {
         node: Node::Type {
             name: Symbol::from(ty.name()),
             generics: vec![],
-            fields: vec![],
+            fields: TypeFields::None,
             with: None,
         },
     }
 }
 
-pub fn function(name: &str, args: Vec<TypedValue>, return_type: Option<TypeArgument>) -> Ast {
+pub fn function(name: &str, args: Vec<TypedValue>, return_type: Option<Type>) -> Ast {
     Ast {
         location: SpanTuple::builtin(),
         node: Node::Function {

--- a/builtins/src/builder.rs
+++ b/builtins/src/builder.rs
@@ -2,7 +2,7 @@
 
 use crate::BuiltinType;
 
-use ast::{Ast, Declaration, FunctionKind, Node, Type, TypeFields, TypeKind, TypedValue};
+use ast::{Ast, Declaration, FunctionKind, Node, Type, TypeContent, TypeKind, TypedValue};
 use location::SpanTuple;
 use symbol::Symbol;
 
@@ -28,7 +28,7 @@ pub fn ty(ty: BuiltinType) -> Ast {
         node: Node::Type {
             name: Symbol::from(ty.name()),
             generics: vec![],
-            fields: TypeFields::None,
+            fields: TypeContent::None,
             with: None,
         },
     }

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -253,6 +253,9 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 let instance = if fields.is_empty() {
                     Instance::empty()
                 } else {
+                    // TODO: At the moment, this fails because `type Foo = Bar` is desugared
+                    // as one record type `type Foo(@type-alias-field: Bar)` which is not correct
+                    // to handle this we can have a better `fields` structure maybe?
                     unreachable!()
                 };
 

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -240,7 +240,7 @@ impl<'ast> AstInfo<'ast> {
         }
     }
 
-    /// Fetch the [`AstInfo::Node`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is actually an [`AstInfo::Helper`]
+    /// Fetch the [`AstInfo::Node`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is *not* an [`AstInfo::Ast`]
     pub fn node(&self) -> &Ast {
         match self {
             AstInfo::Node(node) => node,
@@ -248,7 +248,7 @@ impl<'ast> AstInfo<'ast> {
         }
     }
 
-    /// Fetch the [`AstInfo::Node`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is actually an [`AstInfo::Helper`]
+    /// Fetch the [`AstInfo::Node`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is *not* an [`AstInfo::Type`]
     pub fn type_node(&self) -> &Type {
         match self {
             AstInfo::Type(ty) => ty,
@@ -256,7 +256,7 @@ impl<'ast> AstInfo<'ast> {
         }
     }
 
-    /// Fetch the [`AstInfo::Helper`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is actually an [`AstInfo::Node`]
+    /// Fetch the [`AstInfo::Helper`] from an [`AstInfo`]. This function will panic if the [`AstInfo`] is *not* an [`AstInfo::Helper`]
     pub fn helper(&self) -> (&Symbol, &SpanTuple) {
         match self {
             AstInfo::Helper(sym, loc) => (sym, loc),

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -683,7 +683,9 @@ impl<'ast> Ctx<'ast> {
         ctx.append(data, kind)
     }
 
-    fn handle_type_fields(self, fields: &'ast TypeFields) -> (Ctx<'ast>, Vec<RefIdx>) {}
+    fn handle_type_fields(self, fields: &'ast TypeFields) -> (Ctx<'ast>, Vec<RefIdx>) {
+        todo!()
+    }
 
     fn visit_type(
         self,
@@ -693,13 +695,18 @@ impl<'ast> Ctx<'ast> {
         _with: &Option<Box<Ast>>,
     ) -> (Ctx<'ast>, RefIdx) {
         let (ctx, generics) = self.visit_fold(generics.iter(), Ctx::handle_generic_node);
-        let kind = match fields {
-            TypeFields::None => Kind::Type { generics },
-            TypeFields::Record(_) => todo!(),
-            TypeFields::Tuple(_) => todo!(),
-            // how do we handle generic type aliases? `type Foo[T] = Bar[T]`
-            TypeFields::Alias(_) => Kind::TypeReference(RefIdx::Unresolved),
-        };
+        // let kind = match fields {
+        //     TypeFields::None => Kind::Type {
+        //         generics,
+        //         fields: vec![],
+        //     },
+        //     TypeFields::Record(fields) => {
+        //         let (ctx, fields)
+        //     },
+        //     TypeFields::Tuple(_) => todo!(),
+        //     // how do we handle generic type aliases? `type Foo[T] = Bar[T]`
+        //     TypeFields::Alias(_) => Kind::TypeReference(RefIdx::Unresolved),
+        // };
 
         let (ctx, fields) = ctx.handle_type_fields(fields);
 

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -153,8 +153,8 @@
 //! ```
 
 use ast::{
-    Ast, Call, Declaration, GenericArgument, LoopKind, Node as AstNode, TypeArgument, TypeKind,
-    TypedValue,
+    Ast, Call, Declaration, GenericArgument, LoopKind, Node as AstNode, TypeArgument, TypeFields,
+    TypeKind, TypedValue,
 };
 use fir::{Fir, Kind, Node, OriginIdx, RefIdx};
 use location::SpanTuple;
@@ -683,15 +683,25 @@ impl<'ast> Ctx<'ast> {
         ctx.append(data, kind)
     }
 
+    fn handle_type_fields(self, fields: &'ast TypeFields) -> (Ctx<'ast>, Vec<RefIdx>) {}
+
     fn visit_type(
         self,
         ast: AstInfo<'ast>,
         generics: &[GenericArgument],
-        fields: &'ast [TypedValue],
+        fields: &'ast TypeFields,
         _with: &Option<Box<Ast>>,
     ) -> (Ctx<'ast>, RefIdx) {
         let (ctx, generics) = self.visit_fold(generics.iter(), Ctx::handle_generic_node);
-        let (ctx, fields) = ctx.visit_fold(fields.iter(), Ctx::handle_declaration_argument);
+        let kind = match fields {
+            TypeFields::None => Kind::Type { generics },
+            TypeFields::Record(_) => todo!(),
+            TypeFields::Tuple(_) => todo!(),
+            // how do we handle generic type aliases? `type Foo[T] = Bar[T]`
+            TypeFields::Alias(_) => Kind::TypeReference(RefIdx::Unresolved),
+        };
+
+        let (ctx, fields) = ctx.handle_type_fields(fields);
 
         // FIXME: Handle `with` properly
 

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -306,7 +306,9 @@ impl<'ast> Ctx<'ast> {
         let data = FlattenData {
             ast: AstInfo::Helper(
                 match &ty.kind {
-                    TypeKind::Ty(s) => s.clone(),
+                    // TODO: how do we handle multi types properly here?
+                    TypeKind::Simple(s) => s.clone(),
+                    TypeKind::Multi(_) => Symbol::from("multi"),
                     TypeKind::FunctionLike(_, _) => Symbol::from("func"), // FIXME: Invalid but w/ever for now
                 },
                 ty.location.clone(),

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -244,6 +244,8 @@ impl NameResolutionError {
                 //     }
                 // });
 
+                // FIXME: factor this with the typechecker for the colorization of the type in purple
+                // this should probably be part of the `error` module, with a function like `error::format::ty`
                 Error::new(ErrKind::NameResolution)
                     .with_msg(format!("unresolved {kind}: `{sym}`"))
                     .with_loc(location)

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -600,4 +600,79 @@ mod tests {
 
         assert!(fir.is_ok())
     }
+
+    #[test]
+    fn multi_type_nameres_invalid() {
+        let ast = ast! {
+            type Foo = Bar | Baz;
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_err())
+    }
+
+    #[test]
+    #[ignore]
+    fn multi_type_nameres_valid() {
+        let ast = ast! {
+            type Bar;
+            type Baz;
+            type Foo = Bar | Baz;
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_ok())
+    }
+
+    #[test]
+    fn multi_type_nameres_fn_arg_valid() {
+        let ast = ast! {
+            type Bar;
+            type Baz;
+            func foo(a: Bar | Baz) {}
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_ok())
+    }
+
+    #[test]
+    fn multi_type_nameres_fn_arg_invalid() {
+        let ast = ast! {
+            type Bar;
+            func foo(a: Bar | Baz) {}
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_err())
+    }
+
+    #[test]
+    fn multi_type_in_record_nameres_valid() {
+        let ast = ast! {
+            type Bar;
+            type Baz;
+            type Foo(inner: Bar | Baz);
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_ok())
+    }
+
+    #[test]
+    fn multi_type_in_record_nameres_invalid() {
+        let ast = ast! {
+            type Bar;
+            type Foo(inner: Bar | Baz);
+        };
+
+        let fir = ast.flatten().name_resolve();
+
+        assert!(fir.is_err())
+    }
 }

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -150,6 +150,7 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         origin: OriginIdx,
         _reference: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
+        dbg!(origin);
         let definition = self.get_definition(
             ResolveKind::Type,
             data.ast.symbol(),

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -151,6 +151,8 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         _reference: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
         dbg!(origin);
+        // how do we handle references to multi types here?
+
         let definition = self.get_definition(
             ResolveKind::Type,
             data.ast.symbol(),

--- a/xparser/src/constructs.rs
+++ b/xparser/src/constructs.rs
@@ -16,7 +16,6 @@
 use super::tokens;
 use super::{Error, ParseInput, ParseResult};
 
-use ast::Ast;
 use ast::Call;
 use ast::Declaration;
 use ast::FunctionKind;
@@ -27,6 +26,7 @@ use ast::TypeArgument;
 use ast::TypeKind;
 use ast::TypedValue;
 use ast::Value;
+use ast::{Ast, TypeFields};
 use location::Location;
 use location::SpanTuple;
 use nom::sequence::tuple;
@@ -549,26 +549,20 @@ fn unit_type_decl(input: ParseInput, start_loc: Location) -> ParseResult<ParseIn
             Node::Type {
                 name: Symbol::from(name),
                 generics,
-                fields,
+                fields: TypeFields::Record(fields),
                 with: None, // TODO: Parse `with` block properly
             },
         )
     } else if let Ok((input, _)) = tokens::equal(input) {
         let input = next(input);
-        let (input, start_loc) = position(input)?;
         let (input, type_aliased) = type_id(input)?;
-        let (input, end_loc) = position(input)?;
         (
             input,
             Node::Type {
                 name: Symbol::from(name),
                 generics,
                 // FIXME: this is invalid
-                fields: vec![TypedValue {
-                    location: pos_to_loc(input, start_loc, end_loc),
-                    symbol: Symbol::from("@type-alias-field"),
-                    ty: type_aliased,
-                }],
+                fields: TypeFields::Alias(type_aliased),
                 with: None,
             },
         )
@@ -578,7 +572,7 @@ fn unit_type_decl(input: ParseInput, start_loc: Location) -> ParseResult<ParseIn
             Node::Type {
                 name: Symbol::from(name),
                 generics,
-                fields: vec![],
+                fields: TypeFields::None,
                 with: None,
             },
         )

--- a/xparser/src/constructs.rs
+++ b/xparser/src/constructs.rs
@@ -26,7 +26,7 @@ use ast::Type;
 use ast::TypeKind;
 use ast::TypedValue;
 use ast::Value;
-use ast::{Ast, TypeFields};
+use ast::{Ast, TypeContent};
 use location::Location;
 use location::SpanTuple;
 use nom::sequence::tuple;
@@ -549,7 +549,7 @@ fn unit_type_decl(input: ParseInput, start_loc: Location) -> ParseResult<ParseIn
             Node::Type {
                 name: Symbol::from(name),
                 generics,
-                fields: TypeFields::Record(fields),
+                fields: TypeContent::Record(fields),
                 with: None, // TODO: Parse `with` block properly
             },
         )
@@ -562,7 +562,7 @@ fn unit_type_decl(input: ParseInput, start_loc: Location) -> ParseResult<ParseIn
                 name: Symbol::from(name),
                 generics,
                 // FIXME: this is invalid
-                fields: TypeFields::Alias(type_aliased),
+                fields: TypeContent::Alias(type_aliased),
                 with: None,
             },
         )
@@ -572,7 +572,7 @@ fn unit_type_decl(input: ParseInput, start_loc: Location) -> ParseResult<ParseIn
             Node::Type {
                 name: Symbol::from(name),
                 generics,
-                fields: TypeFields::None,
+                fields: TypeContent::None,
                 with: None,
             },
         )


### PR DESCRIPTION
- xparser: Parse multi types properly
- ast: Add note about renaming TypeArgument
- flatten: Add handling for AST types
- [wip]: from this point on in the log I'm buzzed
- flatten: [wip] Start handling TypeFields properly
- xparser: Generate proper TypeField
- fir: Rename Kind::Type to Kind::RecordType
- fir: Add Kind::UnionType
- fir: [wip] Fix checks for union types
- flatten: Handle multi-types properly
- name_resolve: [wip]: add tests
