### PR TITLE
Implement base type-level interpreter and subtyping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arrayref"
@@ -79,9 +79,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "blake2b_simd"
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "cc"
@@ -167,12 +167,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "debug-fir"
@@ -209,7 +206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.3",
+ "redox_users 0.4.4",
  "winapi",
 ]
 
@@ -233,12 +230,12 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -257,9 +254,9 @@ checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "fd-lock"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f7a0db71c99f68398f80653ed05afb0b00e062e1a20c7ff849c4edfabbbcc"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -315,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -404,9 +401,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libffi"
@@ -439,6 +436,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
 name = "linefeed"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "location"
@@ -481,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "minimal-lexical"
@@ -497,7 +505,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c624fa1b7aab6bd2aff6e9b18565cc0363b6d45cbcd7465c9ed5e3740ebf097"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "nix 0.26.4",
  "smallstr",
@@ -511,6 +519,7 @@ dependencies = [
 name = "name_resolve"
 version = "0.1.0"
 dependencies = [
+ "colored",
  "debug-fir",
  "distance",
  "error",
@@ -547,7 +556,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -637,18 +646,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -699,9 +708,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -719,12 +728,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
+ "getrandom 0.2.12",
+ "libredox",
  "thiserror",
 ]
 
@@ -742,15 +751,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -759,7 +768,7 @@ version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -792,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "strsim"
@@ -846,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,22 +888,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -17,15 +17,15 @@ pub enum TypeKind {
 /// A type argument, i.e. when performing a specific generic call or specifying a variable's type
 ///
 /// ```ignore
-/// a: int = id<int>(15);
+/// a: int = id[int](15);
 ///
 /// a: int = 15;
 /// a: int | string = if true { "jinko" } else { 14 };
 ///
-/// func f(arg: Vector<int>) {}
-/// func g(arg: Tuple<int, float>) {}
-/// func h(arg: Tuple<int, Tuple<Vector<float>, string>>) {}
-/// func apply_fn(arg: int, fn: func(int) -> int) -> int { fn(arg) }
+/// func f(arg: Vector[int]) {}
+/// func g(arg: Tuple[int, float]) {}
+/// func h(arg: Tuple[int, Tuple[Vector[float], string]) {}
+/// func apply_fn(arg: int, fn: int -> int) -> int { fn(arg) }
 /// ```
 #[derive(Debug, Clone)]
 pub struct Type {

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -76,7 +76,7 @@ impl<T: Debug> Fir<T> {
                         , node);
                 }
                 // FIXME: Is that okay?
-                Kind::TypeReference(to) => check!(to => Kind::RecordType { .. } | Kind::UnionType { .. } |  Kind::Generic { .. }, node),
+                Kind::TypeReference(to) => check!(to => Kind::RecordType { .. } | Kind::UnionType { .. } |  Kind::Generic { .. } | Kind::TypeReference(_), node),
                 Kind::Generic {
                     default: Some(default),
                 } => check!(default => Kind::TypeReference { .. }, node),

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -88,7 +88,7 @@ impl<T: Debug> Fir<T> {
                 } => {
                     check!(@generics => Kind::Generic { .. }, node);
                     check!(@args => Kind::Binding { .. }, node);
-                    check!(return_type => Some(Kind::TypeReference { .. }), node);
+                    check!(return_type => Some(Kind::TypeReference { .. } | Kind::UnionType { .. }), node);
                     check!(block => Some(Kind::Statements(_)), node);
                 }
                 Kind::Call {

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -95,7 +95,7 @@
 // Does that make sense? Does that indicate that for all types we must first keep a Option<Ty> which is set to None?
 // Is this going to cause problems?
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::{collections::BTreeMap, ops::Index};
 
@@ -135,7 +135,7 @@ impl RefIdx {
 /// call points or to emit errors.
 /// An origin point - this is where a variable, type or function is defined. Later uses of that
 /// object (variable, type or function) are resolved to [`RefIdx::Resolved`]s.
-#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OriginIdx(pub u64);
 
 impl OriginIdx {
@@ -143,6 +143,15 @@ impl OriginIdx {
     /// and repeatedly call [`next`] on it.
     pub fn next(&self) -> OriginIdx {
         OriginIdx(self.0 + 1)
+    }
+}
+
+impl Debug for OriginIdx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            u64::MAX => write!(f, "OriginIdx::BUILTIN"),
+            any => write!(f, "OriginIdx({any})"),
+        }
     }
 }
 

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -146,7 +146,7 @@ impl OriginIdx {
     }
 }
 
-impl Debug for OriginIdx {
+impl fmt::Debug for OriginIdx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             u64::MAX => write!(f, "OriginIdx::BUILTIN"),

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -397,6 +397,7 @@ mod tests {
         ($($toks:tt)*) => {
             {
                 let ast = xparser::ast!(
+                    type unit;
                     type char;
                     type bool;
                     type int;

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -744,7 +744,7 @@ impl<'ast> Ctx<'ast> {
                 ctx.append(data, Kind::TypeReference(aliased))
             }
             TypeContent::Tuple(_) => todo!("tuple fields are not handled yet: map to a RecordType with fields named `.0`, `.1`..."),
-            _ => todo!("function-like types are not handled yet")
+            // FIXME: function-like types are not handled yet
         }
     }
 

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -738,14 +738,11 @@ impl<'ast> Ctx<'ast> {
             },
             // FIXME: Surely there is something we need to do with generics here and in the following variants, right?
             // TODO: Add Kind::TypeAlias?
-            TypeContent::Alias(ty @ Type { kind: TypeKind::Multi(variants), .. }) => {
-                let (ctx, aliased) = self.handle_multi_type(ty, generics, variants);
+            TypeContent::Alias(ty) => {
+                let (ctx, aliased) = self.handle_type_node(ty);
 
                 ctx.append(data, Kind::TypeReference(aliased))
-            },
-            TypeContent::Alias(Type { kind: TypeKind::Simple(_), .. }) => {
-                self.append(data, Kind::TypeReference(RefIdx::Unresolved))
-            },
+            }
             TypeContent::Tuple(_) => todo!("tuple fields are not handled yet: map to a RecordType with fields named `.0`, `.1`..."),
             _ => todo!("function-like types are not handled yet")
         }

--- a/name_resolve/Cargo.toml
+++ b/name_resolve/Cargo.toml
@@ -13,6 +13,7 @@ flatten = { path = "../flatten" }
 error = { path = "../error" }
 location = { path = "../location" }
 distance = "0.4"
+colored = "2.1.0"
 
 [dev-dependencies]
 xparser = { path = "../xparser" }

--- a/name_resolve/src/declarator.rs
+++ b/name_resolve/src/declarator.rs
@@ -67,6 +67,21 @@ impl<'ast, 'ctx, 'enclosing> Traversal<FlattenData<'ast>, NameResolutionError>
         self.define(DefinitionKind::Type, node)
     }
 
+    fn traverse_type_reference(
+        &mut self,
+        _fir: &Fir<FlattenData<'ast>>,
+        node: &Node<FlattenData<'ast>>,
+        reference: &RefIdx,
+    ) -> Fallible<NameResolutionError> {
+        // if we already see resolved type references, then it means we are dealing
+        // with a type alias
+        if let RefIdx::Resolved(_) = reference {
+            self.define(DefinitionKind::Type, node)
+        } else {
+            Ok(())
+        }
+    }
+
     fn traverse_binding(
         &mut self,
         _: &Fir<FlattenData>,

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -37,6 +37,7 @@
 
 use std::{collections::HashMap, mem, ops::Index};
 
+use colored::Colorize;
 use error::{ErrKind, Error};
 use fir::{Fallible, Fir, Incomplete, Kind, Mapper, OriginIdx, Pass, Traversal};
 use flatten::FlattenData;
@@ -247,7 +248,7 @@ impl NameResolutionError {
                 // FIXME: factor this with the typechecker for the colorization of the type in purple
                 // this should probably be part of the `error` module, with a function like `error::format::ty`
                 Error::new(ErrKind::NameResolution)
-                    .with_msg(format!("unresolved {kind}: `{sym}`"))
+                    .with_msg(format!("unresolved {kind}: `{}`", sym.access().purple()))
                     .with_loc(location)
             }
             NameResolutionError::AmbiguousBinding(lhs, rhs, location) => {

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -151,7 +151,7 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         reference: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
         // short circuit in case the type-reference was already resolved - this can happen for
-        // things like type aliases where we can create type reference during flattening
+        // things like type aliases where we can create type references during flattening
         if let RefIdx::Resolved(_) = reference {
             Ok(Node {
                 data,

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -39,7 +39,7 @@ impl<'ctx, 'enclosing> Resolver<'ctx, 'enclosing> {
 
         let mappings = &self.0.mappings;
 
-        let scope = self.0.enclosing_scope[dbg!(node)];
+        let scope = self.0.enclosing_scope[node];
 
         let origin = match kind {
             ResolveKind::Call => mappings.functions.lookup(symbol, scope),
@@ -150,7 +150,6 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         origin: OriginIdx,
         _reference: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
-        dbg!(origin);
         // how do we handle references to multi types here?
 
         let definition = self.get_definition(

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -306,7 +306,7 @@ impl<'ctx> TypeLinkResolver<'ctx> {
         let ty_of_node = self.old.types.get(&to_resolve).unwrap();
 
         match ty_of_node {
-            Some(TypeVariable::Reference(ty_ref)) => {
+            TypeVariable::Reference(ty_ref) => {
                 intermediate_nodes.push(to_resolve);
 
                 self.find_end_inner(
@@ -317,7 +317,7 @@ impl<'ctx> TypeLinkResolver<'ctx> {
                     intermediate_nodes,
                 )
             }
-            Some(TypeVariable::Record(r)) => {
+            TypeVariable::Record(r) => {
                 // we don't insert here so that we can get the typeref directly later on - does that make sense?
                 // self.new.types.new_type(final_type.clone());
 
@@ -327,7 +327,7 @@ impl<'ctx> TypeLinkResolver<'ctx> {
                     final_type: Type::single(*r),
                 })
             }
-            Some(TypeVariable::Union(u)) => {
+            TypeVariable::Union(u) => {
                 let original_node = &fir.nodes[u];
                 let variants = match &original_node.kind {
                     Kind::UnionType { variants, .. } => variants,
@@ -349,13 +349,6 @@ impl<'ctx> TypeLinkResolver<'ctx> {
                     final_type: Type::new(*u, variants.collect()),
                 })
             }
-            // FIXME: Remove None as the type for void types
-            // nothing to do
-            // FIXME: This is invalid
-            None => ControlFlow::Break(ChainEnd {
-                intermediate_nodes,
-                final_type: Type::builtin(HashSet::new()),
-            }),
         }
     }
 

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -1,7 +1,7 @@
 // TODO: explain why this step is important as one could think we can just compare the results of Typer for equality, e.g. type_variable1 == type_variable2.
 // TODO: but actually we need to be able to handle everything that the actual typesystem will rely on, such as subtyping
 
-use std::{collections::HashSet, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 use error::Error;
 use fir::{Fallible, Fir, Kind, Node, OriginIdx, RefIdx, Traversal};
@@ -13,166 +13,6 @@ use crate::{typemap::TypeMap, Type, TypeCtx, TypeLinkMap, TypeVariable};
 /// the previous module ([`crate::typer`]), a list will be built within the [`TypeCtx`] containing "type links".
 /// This pass will resolve these links and make each node point to its *actual* type.
 pub(crate) struct Actual; // <'ctx>(pub(crate) &'ctx mut TypeCtx);
-
-// what should the interface look like so that we can have
-// let typectx = Actual(typectx).traverse(fir);
-
-// fn resolve_type_chain_RENAME_ME(
-//     ctx: &TypeCtx<TypeLinkMap>,
-//     new: &mut TypeCtx<TypeMap>,
-//     fir: &Fir<FlattenData<'_>>,
-//     linked_node: RefIdx,
-//     // this should probably return the Origin as well? so we can do some magic with the node after
-// ) {
-//     // FIXME: Remove mutability, make it more functional
-//     let ty = ctx.types.get(&linked_node.expect_resolved()).unwrap();
-
-//     // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
-//     // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
-//     // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
-//     // this returns a TypeRef with which we insert for all the nodes in the chain?
-//     // this function should probably be renamed
-
-//     // FIXME: This API does not work with what we've done so far
-//     loop {
-//         let mut intermediate_nodes = vec![];
-
-//         match ty {
-//             Some(TypeVariable::Reference(referenced_ty)) => intermediate_nodes.push(referenced_ty),
-//             _ => todo!(),
-//             // Some(TypeVariable::Actual(ty)) => {}
-//         }
-//     }
-// }
-
-// fn innermost_type(
-//     ctx: &TypeCtx<TypeLinkMap>,
-//     fir: &Fir<FlattenData<'_>>,
-//     linked_node: RefIdx,
-//     // this should probably return the Origin as well? so we can do some magic with the node after
-// ) -> Option<Type> {
-//     let linked_node = linked_node.expect_resolved();
-
-//     // how do we improve that?
-//     // make it functional/recursive?
-//     // then handle TypeReference/RecordType/UnionType?
-
-//     // so can we replace all of this by a permanent lookup until we find a Type::Actual?
-//     // probably, right?
-//     // and we won't need the FIR as a parameter anymore
-//     let ty = ctx.types.get(&linked_node);
-
-//     // we get the typevariable here - if it does not exist, we should error out because that means this node hasn't been typed at all which is an error
-//     // then we look at it. we kinda want to iterate until we find a Union/Record, and then walk back the chain maybe?
-
-//     // when we find a Union/Record, we create a Type and a TypeRef, insert them into the TypeMap
-//     // actually I don't think that's how it works :(
-
-//     match ty {
-//         Some(ty) => match ty {
-//             Some(ty) => match ty {
-//                 // This is an issue - we can run into situations where we have an `Actual` which
-//                 // points to an `fir::Kind::TypeReference` - so we must extract that
-//                 TypeVariable::Actual(ty) => {
-//                     if ty.set().0.len() == 1 {
-//                         // If we have only one type in the typeset, it might be a typereference - if that is the case,
-//                         // `innermost_type` it again
-//                         let referenced_ty = ty.set().0.iter().next().unwrap();
-//                         let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
-//                         let origin = referenced_node.origin;
-
-//                         match &referenced_node.kind {
-//                             Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
-//                             Kind::RecordType { .. } => Some(Type::single(
-//                                 origin,
-//                                 RefIdx::Resolved(referenced_node.origin),
-//                             )),
-//                             Kind::UnionType { variants, .. } => Some(Type::new(
-//                                 origin,
-//                                 variants
-//                                     .into_iter()
-//                                     .map(|variant| innermost_type(ctx, fir, *variant))
-//                                     .map(|variant| {
-//                                         variant.unwrap().set().0.iter().copied().next().unwrap()
-//                                     })
-//                                     .collect(),
-//                             )),
-//                             _ => unreachable!(),
-//                         }
-//                     } else {
-//                         todo!()
-//                         // Some(Type::new(
-//                         //     ty.set()
-//                         //         .0
-//                         //         .iter()
-//                         //         .map(|variant| innermost_type(ctx, fir, *variant))
-//                         //         .map(|variant| {
-//                         //             variant.unwrap().set().0.iter().copied().next().unwrap()
-//                         //         })
-//                         //         .collect(),
-//                         // ))
-//                     }
-//                     // if let Kind::TypeReference(r) = referenced_node.kind {
-//                     //     innermost_type(ctx, fir, r)
-//                     // } else {
-//                     //     // FIXME: Remove clone
-//                     //     Some(ty.clone())
-//                     // }
-//                 }
-//                 TypeVariable::Reference(r) => innermost_type(ctx, fir, *r),
-//             },
-//             None => return None,
-//         },
-//         None => todo!(),
-//     }
-
-//     //     // if the context contains an entry for `linked_node`, then we use this - otherwise, we simply
-//     //     // get the node from the FIR
-//     //     let to_lookup = &ctx
-//     //         .types
-//     //         .get(&linked_node)
-//     //         .and_then(|ty| ty.map(|t| t.ref_idx().expect_resolved()))
-//     //         .unwrap_or(linked_node);
-
-//     //     let linked_node = &fir.nodes[to_lookup];
-
-//     //     let inner_opt = |fir, opt| match opt {
-//     //         Some(opt) => innermost_type(ctx, fir, opt),
-//     //         None => None,
-//     //     };
-
-//     //     match &linked_node.kind {
-//     //         // shouldn't we instead stop when we find a TypeVariable::Actual?
-//     //         // these are the *only* terminal branches
-//     //         Kind::RecordType { .. } | Kind::UnionType { .. } => {
-//     //             Some(Type::One(RefIdx::Resolved(linked_node.origin)))
-//     //         }
-//     //         Kind::Assignment { .. } => None,
-//     //         // if a typed value has no specific type, but points to a value, use this as the source of the type
-//     //         Kind::TypedValue {
-//     //             ty: RefIdx::Unresolved,
-//     //             value,
-//     //             // can we set `ty` here or not? probably not
-//     //             // we need to :(
-//     //         } => innermost_type(ctx, fir, *value),
-//     //         Kind::Constant(ty)
-//     //         | Kind::TypeReference(ty)
-//     //         | Kind::TypedValue { ty, .. }
-//     //         | Kind::Binding { to: ty }
-//     //         | Kind::Instantiation { to: ty, .. }
-//     //         | Kind::Call { to: ty, .. }
-//     //         | Kind::Conditional { true_block: ty, .. } => innermost_type(ctx, fir, *ty),
-//     //         Kind::Function {
-//     //             return_type: ty, ..
-//     //         }
-//     //         | Kind::Return(ty) => inner_opt(fir, *ty),
-//     //         Kind::Statements(stmts) => inner_opt(fir, stmts.last().copied()),
-//     //         // FIXME: What to do here?
-//     //         Kind::Generic { .. } => todo!(),
-//     //         Kind::Loop { .. } => todo!(),
-//     //         Kind::TypeOffset { .. } => todo!(),
-//     //     }
-// }
 
 struct TypeLinkResolver<'ctx> {
     old: &'ctx TypeCtx<TypeLinkMap>,
@@ -198,67 +38,6 @@ impl Actual {
     }
 }
 
-// think of the APIs we want
-/*
-we want to:
-
-1. find the origin type from a node, so the end of the chain
-2. as we do that, we want to build a list of intermediate nodes which will need their types updated
-3. so something like find_end() -> <Vec<OriginIdx>, Type>
-
-4. we call find_end(), create a TypeRef, update all the intermediate nodes
-
-let (intermediate, ty) = find_end();
-
-let ref = self.new.insert_type(ty);
-intermediate.into_iter().for_each(|node| self.new.insert(node, ref));
-
-// done!
-
-now this should also return the OriginIdx of the type we've just found - this way we can flatten union types properly right?
-
-should Type keep a hashset of RefIdx? why not OriginIdx? probably better to have OriginIdx at this point.
-
-so this function that does the `find_end` and update should probably return an OriginIdx of the type we've just resolved
-
-so
-
-// is it fallible? or not?
-
-fn resolve_link(&mut self, to_resolve: OriginIdx, fir: &'fir Fir<FlattenData>) -> OriginIdx {
-    let (intermediate, ty) = find_end();
-
-    let node = ty.0;
-    let tyref = self.new.insert_type(ty);
-
-    intermediate.into_iter().for_each(|node| self.new.insert(node, tyref));
-
-    node
-}
-
-// FIXME: Rename
-struct ChainEnd {
-    intermediate_nodes: Vec<OriginIdx>,
-    final_type: Type,
-}
-
-struct ResolutionCtx<'fir> {
-    fir: &'fir Fir<FlattenData>,
-    to_resolve: OriginIdx,
-}
-
-fn find_end_inner(to_resolve: ResolutionCtx, intermediate_nodes: Vec<OriginIdx>) -> ControlFlow<Continue: Vec<OriginIdx>, Break: ChainEnd> {
-    match
-}
-
-fn find_end(to_resolve: ResolutionCtx) -> ChainEnd {
-    let intermediate_nodes = vec![];
-
-    let rec = find_end_inner(to_resolve, intermediate_nodes)
-}
-
-*/
-
 struct ChainEnd {
     intermediate_nodes: Vec<OriginIdx>,
     final_type: Type,
@@ -272,11 +51,7 @@ struct ResolutionCtx<'ast, 'fir> {
 impl<'ctx> TypeLinkResolver<'ctx> {
     /// Recursively try and resolve a type link within the type context. This will update the given node's type
     /// within the type context.
-    fn resolve_link_v2<'fir>(
-        &mut self,
-        to_resolve: OriginIdx,
-        fir: &'fir Fir<FlattenData>,
-    ) -> OriginIdx {
+    fn resolve_link(&mut self, to_resolve: OriginIdx, fir: &Fir<FlattenData>) -> OriginIdx {
         let resolution_ctx = ResolutionCtx { fir, to_resolve };
 
         let ChainEnd {
@@ -336,17 +111,16 @@ impl<'ctx> TypeLinkResolver<'ctx> {
 
                 // FIXME: This can cause an infinite loop - how to prevent that?
                 let variants = variants
-                    .into_iter()
-                    .map(|variant| self.resolve_link_v2(variant.expect_resolved(), fir))
-                    .map(|origin| RefIdx::Resolved(origin));
+                    .iter()
+                    .map(|variant| self.resolve_link(variant.expect_resolved(), fir))
+                    .map(RefIdx::Resolved);
 
                 // we don't insert here so that we can get the typeref directly later on - does that make sense?
                 // self.new.types.new_type(final_type.clone());
 
-                // FIXME: No clone - Actual() should probably keep an OriginIdx rather than a Type
                 ControlFlow::Break(ChainEnd {
                     intermediate_nodes,
-                    final_type: Type::new(*u, variants.collect()),
+                    final_type: Type::union(*u, variants),
                 })
             }
         }
@@ -360,103 +134,6 @@ impl<'ctx> TypeLinkResolver<'ctx> {
             ControlFlow::Continue(_) => unreachable!(),
         }
     }
-
-    // fn resolve_link(
-    //     &mut self,
-    //     fir: &Fir<FlattenData<'_>>,
-    //     to_resolve: OriginIdx,
-    // ) -> Fallible<Error> {
-    //     // FIXME: Remove mutability, make it more functional
-
-    //     // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
-    //     // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
-    //     // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
-    //     // this returns a TypeRef with which we insert for all the nodes in the chain?
-    //     // this function should probably be renamed
-
-    //     let mut intermediate_nodes = vec![];
-    //     let mut current = to_resolve;
-
-    //     // FIXME: This API does not work with what we've done so far
-    //     loop {
-    //         // if any node has not been through "Typer" before, this is an interpreter error
-    //         let ty = self.old.types.get(&current).unwrap();
-
-    //         match ty {
-    //             None => todo!(),
-    //             Some(TypeVariable::Reference(referenced_ty)) => {
-    //                 let node = referenced_ty.expect_resolved();
-
-    //                 intermediate_nodes.push(node);
-    //                 current = node;
-    //             }
-    //             Some(TypeVariable::Actual(ty)) => {
-    //                 if ty.set().0.len() == 1 {
-    //                     // If we have only one type in the typeset, it might be a typereference - if that is the case,
-    //                     // `innermost_type` it again
-    //                     // FIXME: This needs more explaining
-    //                     let referenced_ty = ty.set().0.iter().next().unwrap();
-    //                     let node = referenced_ty.expect_resolved();
-
-    //                     let kind = fir[&node].kind;
-
-    //                     match kind {
-    //                         Kind::TypeReference(r) => {
-    //                             intermediate_nodes.push(node);
-    //                             current = r.expect_resolved();
-    //                         }
-    //                         // we found an actual type definition - insert it, break the loop and type
-    //                         // all the intermediate nodes
-    //                         Kind::RecordType { fields, .. } => {
-    //                             let ty = Type::single(node, RefIdx::Resolved(node));
-
-    //                             self.new.types.new_type(node, ty);
-    //                         }
-    //                         Kind::UnionType { variants, .. } => {
-    //                             todo!()
-    //                             // FIXME: How do we get the actual type here? we need to go through innermost_type again? :(
-    //                             // how are types represented in that case? Type::Set { OriginIdx, OriginIdx, OriginIdx }?
-    //                             // so we need to have these nodes typed already and to get their type from the typemap?
-    //                             //         variants
-    //                             //             .into_iter()
-    //                             //             .map(|variant| innermost_type(ctx, fir, *variant))
-    //                             //             .map(|variant| {
-    //                             //                 variant.unwrap().set().0.iter().copied().next().unwrap()
-    //                             //             })
-    //                             //             .collect(),
-    //                         }
-    //                         _ => unreachable!(),
-    //                     }
-
-    //                     continue;
-    //                 }
-
-    //                 // FIXME: Remove
-    //                 break;
-    //                 // let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
-
-    //                 // match &ty.kind {
-    //                 //     Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
-    //                 //     Kind::RecordType { .. } => {
-    //                 //         Some(Type::single(RefIdx::Resolved(referenced_node.origin)))
-    //                 //     }
-    //                 //     Kind::UnionType { variants, .. } => Some(Type::new(
-    //                 //         variants
-    //                 //             .into_iter()
-    //                 //             .map(|variant| innermost_type(ctx, fir, *variant))
-    //                 //             .map(|variant| {
-    //                 //                 variant.unwrap().set().0.iter().copied().next().unwrap()
-    //                 //             })
-    //                 //             .collect(),
-    //                 //     )),
-    //                 //     _ => unreachable!(),
-    //                 // }
-    //             }
-    //         }
-    //     }
-
-    //     Ok(())
-    // }
 }
 
 impl<'ctx> Traversal<FlattenData<'_>, Error> for TypeLinkResolver<'ctx> {
@@ -465,7 +142,7 @@ impl<'ctx> Traversal<FlattenData<'_>, Error> for TypeLinkResolver<'ctx> {
         fir: &Fir<FlattenData>,
         node: &Node<FlattenData>,
     ) -> Fallible<Error> {
-        self.resolve_link_v2(node.origin, fir);
+        self.resolve_link(node.origin, fir);
 
         Ok(())
     }

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -2,81 +2,295 @@ use error::Error;
 use fir::{Fallible, Fir, Kind, Node, OriginIdx, RefIdx, Traversal};
 use flatten::FlattenData;
 
-use crate::{Type, TypeCtx};
+use crate::{typemap::TypeMap, Type, TypeCtx, TypeLinkMap, TypeVariable};
 
 /// This pass takes care of shortening each link within the type context as much as possible. As explained in
 /// the previous module ([`crate::typer`]), a list will be built within the [`TypeCtx`] containing "type links".
 /// This pass will resolve these links and make each node point to its *actual* type.
-pub(crate) struct Actual<'ctx>(pub(crate) &'ctx mut TypeCtx);
+pub(crate) struct Actual; // <'ctx>(pub(crate) &'ctx mut TypeCtx);
 
-fn innermost_type(ctx: &TypeCtx, fir: &Fir<FlattenData>, linked_node: RefIdx) -> Option<Type> {
-    let linked_node = linked_node.expect_resolved();
+// what should the interface look like so that we can have
+// let typectx = Actual(typectx).traverse(fir);
 
-    // if the context contains an entry for `linked_node`, then we use this - otherwise, we simply
-    // get the node from the FIR
-    let to_lookup = &ctx
-        .types
-        .get(&linked_node)
-        .and_then(|ty| ty.map(|t| t.ref_idx().expect_resolved()))
-        .unwrap_or(linked_node);
+fn resolve_type_chain_RENAME_ME(
+    ctx: &TypeCtx<TypeLinkMap>,
+    new: &mut TypeCtx<TypeMap>,
+    fir: &Fir<FlattenData<'_>>,
+    linked_node: RefIdx,
+    // this should probably return the Origin as well? so we can do some magic with the node after
+) {
+    // FIXME: Remove mutability, make it more functional
+    let ty = ctx.types.get(&linked_node.expect_resolved()).unwrap();
 
-    let linked_node = &fir.nodes[to_lookup];
+    // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
+    // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
+    // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
+    // this returns a TypeRef with which we insert for all the nodes in the chain?
+    // this function should probably be renamed
 
-    let inner_opt = |fir, opt| match opt {
-        Some(opt) => innermost_type(ctx, fir, opt),
-        None => None,
-    };
+    // FIXME: This API does not work with what we've done so far
+    loop {
+        let intermediate_nodes = vec![];
 
-    match &linked_node.kind {
-        // these are the *only* terminal branches
-        Kind::RecordType { .. } | Kind::UnionType { .. } => {
-            Some(Type::One(RefIdx::Resolved(linked_node.origin)))
+        match ty {
+            None => todo!(),
+            Some(TypeVariable::Reference(referenced_ty)) => intermediate_nodes.push(referenced_ty),
+            Some(TypeVariable::Actual(ty)) => {}
         }
-        Kind::Assignment { .. } => None,
-        // if a typed value has no specific type, but points to a value, use this as the source of the type
-        Kind::TypedValue {
-            ty: RefIdx::Unresolved,
-            value,
-            // can we set `ty` here or not? probably not
-            // we need to :(
-        } => innermost_type(ctx, fir, *value),
-        Kind::Constant(ty)
-        | Kind::TypeReference(ty)
-        | Kind::TypedValue { ty, .. }
-        | Kind::Binding { to: ty }
-        | Kind::Instantiation { to: ty, .. }
-        | Kind::Call { to: ty, .. }
-        | Kind::Conditional { true_block: ty, .. } => innermost_type(ctx, fir, *ty),
-        Kind::Function {
-            return_type: ty, ..
-        }
-        | Kind::Return(ty) => inner_opt(fir, *ty),
-        Kind::Statements(stmts) => inner_opt(fir, stmts.last().copied()),
-        // FIXME: What to do here?
-        Kind::Generic { .. } => todo!(),
-        Kind::Loop { .. } => todo!(),
-        Kind::TypeOffset { .. } => todo!(),
     }
 }
 
-impl<'ctx> Actual<'ctx> {
+fn innermost_type(
+    ctx: &TypeCtx<TypeLinkMap>,
+    fir: &Fir<FlattenData<'_>>,
+    linked_node: RefIdx,
+    // this should probably return the Origin as well? so we can do some magic with the node after
+) -> Option<Type> {
+    let linked_node = linked_node.expect_resolved();
+
+    // how do we improve that?
+    // make it functional/recursive?
+    // then handle TypeReference/RecordType/UnionType?
+
+    // so can we replace all of this by a permanent lookup until we find a Type::Actual?
+    // probably, right?
+    // and we won't need the FIR as a parameter anymore
+    let ty = ctx.types.get(&linked_node);
+
+    // we get the typevariable here - if it does not exist, we should error out because that means this node hasn't been typed at all which is an error
+    // then we look at it. we kinda want to iterate until we find a Union/Record, and then walk back the chain maybe?
+
+    // when we find a Union/Record, we create a Type and a TypeRef, insert them into the TypeMap
+    // actually I don't think that's how it works :(
+
+    match ty {
+        Some(ty) => match ty {
+            Some(ty) => match ty {
+                // This is an issue - we can run into situations where we have an `Actual` which
+                // points to an `fir::Kind::TypeReference` - so we must extract that
+                TypeVariable::Actual(ty) => {
+                    if ty.set().0.len() == 1 {
+                        // If we have only one type in the typeset, it might be a typereference - if that is the case,
+                        // `innermost_type` it again
+                        let referenced_ty = ty.set().0.iter().next().unwrap();
+                        let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
+
+                        match &referenced_node.kind {
+                            Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
+                            Kind::RecordType { .. } => {
+                                Some(Type::single(RefIdx::Resolved(referenced_node.origin)))
+                            }
+                            Kind::UnionType { variants, .. } => Some(Type::new(
+                                variants
+                                    .into_iter()
+                                    .map(|variant| innermost_type(ctx, fir, *variant))
+                                    .map(|variant| {
+                                        variant.unwrap().set().0.iter().copied().next().unwrap()
+                                    })
+                                    .collect(),
+                            )),
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        Some(Type::new(
+                            ty.set()
+                                .0
+                                .iter()
+                                .map(|variant| innermost_type(ctx, fir, *variant))
+                                .map(|variant| {
+                                    variant.unwrap().set().0.iter().copied().next().unwrap()
+                                })
+                                .collect(),
+                        ))
+                    }
+                    // if let Kind::TypeReference(r) = referenced_node.kind {
+                    //     innermost_type(ctx, fir, r)
+                    // } else {
+                    //     // FIXME: Remove clone
+                    //     Some(ty.clone())
+                    // }
+                }
+                TypeVariable::Reference(r) => innermost_type(ctx, fir, *r),
+            },
+            None => return None,
+        },
+        None => todo!(),
+    }
+
+    //     // if the context contains an entry for `linked_node`, then we use this - otherwise, we simply
+    //     // get the node from the FIR
+    //     let to_lookup = &ctx
+    //         .types
+    //         .get(&linked_node)
+    //         .and_then(|ty| ty.map(|t| t.ref_idx().expect_resolved()))
+    //         .unwrap_or(linked_node);
+
+    //     let linked_node = &fir.nodes[to_lookup];
+
+    //     let inner_opt = |fir, opt| match opt {
+    //         Some(opt) => innermost_type(ctx, fir, opt),
+    //         None => None,
+    //     };
+
+    //     match &linked_node.kind {
+    //         // shouldn't we instead stop when we find a TypeVariable::Actual?
+    //         // these are the *only* terminal branches
+    //         Kind::RecordType { .. } | Kind::UnionType { .. } => {
+    //             Some(Type::One(RefIdx::Resolved(linked_node.origin)))
+    //         }
+    //         Kind::Assignment { .. } => None,
+    //         // if a typed value has no specific type, but points to a value, use this as the source of the type
+    //         Kind::TypedValue {
+    //             ty: RefIdx::Unresolved,
+    //             value,
+    //             // can we set `ty` here or not? probably not
+    //             // we need to :(
+    //         } => innermost_type(ctx, fir, *value),
+    //         Kind::Constant(ty)
+    //         | Kind::TypeReference(ty)
+    //         | Kind::TypedValue { ty, .. }
+    //         | Kind::Binding { to: ty }
+    //         | Kind::Instantiation { to: ty, .. }
+    //         | Kind::Call { to: ty, .. }
+    //         | Kind::Conditional { true_block: ty, .. } => innermost_type(ctx, fir, *ty),
+    //         Kind::Function {
+    //             return_type: ty, ..
+    //         }
+    //         | Kind::Return(ty) => inner_opt(fir, *ty),
+    //         Kind::Statements(stmts) => inner_opt(fir, stmts.last().copied()),
+    //         // FIXME: What to do here?
+    //         Kind::Generic { .. } => todo!(),
+    //         Kind::Loop { .. } => todo!(),
+    //         Kind::TypeOffset { .. } => todo!(),
+    //     }
+}
+
+struct TypeLinkResolver<'ctx> {
+    old: &'ctx TypeCtx<TypeLinkMap>,
+    new: TypeCtx<TypeMap>,
+}
+
+impl Actual {
+    pub fn resolve_type_links(
+        ctx: &TypeCtx<TypeLinkMap>,
+        fir: &Fir<FlattenData<'_>>,
+    ) -> Result<TypeCtx<TypeMap>, Error> {
+        let mut resolver = TypeLinkResolver {
+            old: ctx,
+            new: TypeCtx {
+                primitives: ctx.primitives.clone(),
+                types: TypeMap::new(),
+            },
+        };
+
+        resolver.traverse(fir)?;
+
+        Ok(resolver.new)
+    }
+}
+
+impl<'ctx> TypeLinkResolver<'ctx> {
     /// Recursively try and resolve a type link within the type context. This will update the given node's type
     /// within the type context.
-    fn resolve_link(&mut self, fir: &Fir<FlattenData>, to_resolve: OriginIdx) -> Fallible<Error> {
-        // if any node has not been through "Typer" before, this is an interpreter error
-        let link = self.0.types.get(&to_resolve).unwrap();
+    fn resolve_link(
+        &mut self,
+        fir: &Fir<FlattenData<'_>>,
+        to_resolve: OriginIdx,
+    ) -> Fallible<Error> {
+        // FIXME: Remove mutability, make it more functional
 
-        // void nodes are already fully typed, so we don't take care of them
-        if let Some(Type::One(ty_ref)) = link {
-            let innermost_ty = innermost_type(self.0, fir, *ty_ref);
-            self.0.types.insert(to_resolve, innermost_ty).unwrap();
+        // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
+        // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
+        // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
+        // this returns a TypeRef with which we insert for all the nodes in the chain?
+        // this function should probably be renamed
+
+        let mut intermediate_nodes = vec![];
+        let mut current = to_resolve;
+
+        // FIXME: This API does not work with what we've done so far
+        loop {
+            // if any node has not been through "Typer" before, this is an interpreter error
+            let ty = self.old.types.get(&current).unwrap();
+
+            match ty {
+                None => todo!(),
+                Some(TypeVariable::Reference(referenced_ty)) => {
+                    let node = referenced_ty.expect_resolved();
+
+                    intermediate_nodes.push(node);
+                    current = node;
+                }
+                Some(TypeVariable::Actual(ty)) => {
+                    if ty.set().0.len() == 1 {
+                        // If we have only one type in the typeset, it might be a typereference - if that is the case,
+                        // `innermost_type` it again
+                        // FIXME: This needs more explaining
+                        let referenced_ty = ty.set().0.iter().next().unwrap();
+                        let node = referenced_ty.expect_resolved();
+
+                        let kind = fir[&node].kind;
+
+                        match kind {
+                            Kind::TypeReference(r) => {
+                                intermediate_nodes.push(node);
+                                current = r.expect_resolved();
+                            }
+                            // we found an actual type definition - insert it, break the loop and type
+                            // all the intermediate nodes
+                            Kind::RecordType { fields, .. } => {
+                                let ty = Type::single(RefIdx::Resolved(node));
+
+                                self.new.types.new_type(node, ty);
+                            }
+                            Kind::UnionType { variants, .. } => {
+                                todo!()
+                                // FIXME: How do we get the actual type here? we need to go through innermost_type again? :(
+                                // how are types represented in that case? Type::Set { OriginIdx, OriginIdx, OriginIdx }?
+                                // so we need to have these nodes typed already and to get their type from the typemap?
+                                //         variants
+                                //             .into_iter()
+                                //             .map(|variant| innermost_type(ctx, fir, *variant))
+                                //             .map(|variant| {
+                                //                 variant.unwrap().set().0.iter().copied().next().unwrap()
+                                //             })
+                                //             .collect(),
+                            }
+                            _ => unreachable!(),
+                        }
+
+                        continue;
+                    }
+
+                    // FIXME: Remove
+                    break;
+                    // let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
+
+                    // match &ty.kind {
+                    //     Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
+                    //     Kind::RecordType { .. } => {
+                    //         Some(Type::single(RefIdx::Resolved(referenced_node.origin)))
+                    //     }
+                    //     Kind::UnionType { variants, .. } => Some(Type::new(
+                    //         variants
+                    //             .into_iter()
+                    //             .map(|variant| innermost_type(ctx, fir, *variant))
+                    //             .map(|variant| {
+                    //                 variant.unwrap().set().0.iter().copied().next().unwrap()
+                    //             })
+                    //             .collect(),
+                    //     )),
+                    //     _ => unreachable!(),
+                    // }
+                }
+            }
         }
 
         Ok(())
     }
 }
 
-impl<'ctx> Traversal<FlattenData<'_>, Error> for Actual<'ctx> {
+impl<'ctx> Traversal<FlattenData<'_>, Error> for TypeLinkResolver<'ctx> {
     fn traverse_node(
         &mut self,
         fir: &Fir<FlattenData>,

--- a/typecheck/src/actual.rs
+++ b/typecheck/src/actual.rs
@@ -1,4 +1,7 @@
-use std::ops::ControlFlow;
+// TODO: explain why this step is important as one could think we can just compare the results of Typer for equality, e.g. type_variable1 == type_variable2.
+// TODO: but actually we need to be able to handle everything that the actual typesystem will rely on, such as subtyping
+
+use std::{collections::HashSet, ops::ControlFlow};
 
 use error::Error;
 use fir::{Fallible, Fir, Kind, Node, OriginIdx, RefIdx, Traversal};
@@ -14,162 +17,162 @@ pub(crate) struct Actual; // <'ctx>(pub(crate) &'ctx mut TypeCtx);
 // what should the interface look like so that we can have
 // let typectx = Actual(typectx).traverse(fir);
 
-fn resolve_type_chain_RENAME_ME(
-    ctx: &TypeCtx<TypeLinkMap>,
-    new: &mut TypeCtx<TypeMap>,
-    fir: &Fir<FlattenData<'_>>,
-    linked_node: RefIdx,
-    // this should probably return the Origin as well? so we can do some magic with the node after
-) {
-    // FIXME: Remove mutability, make it more functional
-    let ty = ctx.types.get(&linked_node.expect_resolved()).unwrap();
+// fn resolve_type_chain_RENAME_ME(
+//     ctx: &TypeCtx<TypeLinkMap>,
+//     new: &mut TypeCtx<TypeMap>,
+//     fir: &Fir<FlattenData<'_>>,
+//     linked_node: RefIdx,
+//     // this should probably return the Origin as well? so we can do some magic with the node after
+// ) {
+//     // FIXME: Remove mutability, make it more functional
+//     let ty = ctx.types.get(&linked_node.expect_resolved()).unwrap();
 
-    // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
-    // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
-    // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
-    // this returns a TypeRef with which we insert for all the nodes in the chain?
-    // this function should probably be renamed
+//     // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
+//     // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
+//     // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
+//     // this returns a TypeRef with which we insert for all the nodes in the chain?
+//     // this function should probably be renamed
 
-    // FIXME: This API does not work with what we've done so far
-    loop {
-        let mut intermediate_nodes = vec![];
+//     // FIXME: This API does not work with what we've done so far
+//     loop {
+//         let mut intermediate_nodes = vec![];
 
-        match ty {
-            None => todo!(),
-            Some(TypeVariable::Reference(referenced_ty)) => intermediate_nodes.push(referenced_ty),
-            Some(TypeVariable::Actual(ty)) => {}
-        }
-    }
-}
+//         match ty {
+//             Some(TypeVariable::Reference(referenced_ty)) => intermediate_nodes.push(referenced_ty),
+//             _ => todo!(),
+//             // Some(TypeVariable::Actual(ty)) => {}
+//         }
+//     }
+// }
 
-fn innermost_type(
-    ctx: &TypeCtx<TypeLinkMap>,
-    fir: &Fir<FlattenData<'_>>,
-    linked_node: RefIdx,
-    // this should probably return the Origin as well? so we can do some magic with the node after
-) -> Option<Type> {
-    let linked_node = linked_node.expect_resolved();
+// fn innermost_type(
+//     ctx: &TypeCtx<TypeLinkMap>,
+//     fir: &Fir<FlattenData<'_>>,
+//     linked_node: RefIdx,
+//     // this should probably return the Origin as well? so we can do some magic with the node after
+// ) -> Option<Type> {
+//     let linked_node = linked_node.expect_resolved();
 
-    // how do we improve that?
-    // make it functional/recursive?
-    // then handle TypeReference/RecordType/UnionType?
+//     // how do we improve that?
+//     // make it functional/recursive?
+//     // then handle TypeReference/RecordType/UnionType?
 
-    // so can we replace all of this by a permanent lookup until we find a Type::Actual?
-    // probably, right?
-    // and we won't need the FIR as a parameter anymore
-    let ty = ctx.types.get(&linked_node);
+//     // so can we replace all of this by a permanent lookup until we find a Type::Actual?
+//     // probably, right?
+//     // and we won't need the FIR as a parameter anymore
+//     let ty = ctx.types.get(&linked_node);
 
-    // we get the typevariable here - if it does not exist, we should error out because that means this node hasn't been typed at all which is an error
-    // then we look at it. we kinda want to iterate until we find a Union/Record, and then walk back the chain maybe?
+//     // we get the typevariable here - if it does not exist, we should error out because that means this node hasn't been typed at all which is an error
+//     // then we look at it. we kinda want to iterate until we find a Union/Record, and then walk back the chain maybe?
 
-    // when we find a Union/Record, we create a Type and a TypeRef, insert them into the TypeMap
-    // actually I don't think that's how it works :(
+//     // when we find a Union/Record, we create a Type and a TypeRef, insert them into the TypeMap
+//     // actually I don't think that's how it works :(
 
-    match ty {
-        Some(ty) => match ty {
-            Some(ty) => match ty {
-                // This is an issue - we can run into situations where we have an `Actual` which
-                // points to an `fir::Kind::TypeReference` - so we must extract that
-                TypeVariable::Actual(ty) => {
-                    if ty.set().0.len() == 1 {
-                        // If we have only one type in the typeset, it might be a typereference - if that is the case,
-                        // `innermost_type` it again
-                        let referenced_ty = ty.set().0.iter().next().unwrap();
-                        let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
-                        let origin = referenced_node.origin;
+//     match ty {
+//         Some(ty) => match ty {
+//             Some(ty) => match ty {
+//                 // This is an issue - we can run into situations where we have an `Actual` which
+//                 // points to an `fir::Kind::TypeReference` - so we must extract that
+//                 TypeVariable::Actual(ty) => {
+//                     if ty.set().0.len() == 1 {
+//                         // If we have only one type in the typeset, it might be a typereference - if that is the case,
+//                         // `innermost_type` it again
+//                         let referenced_ty = ty.set().0.iter().next().unwrap();
+//                         let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
+//                         let origin = referenced_node.origin;
 
-                        match &referenced_node.kind {
-                            Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
-                            Kind::RecordType { .. } => Some(Type::single(
-                                origin,
-                                RefIdx::Resolved(referenced_node.origin),
-                            )),
-                            Kind::UnionType { variants, .. } => Some(Type::new(
-                                origin,
-                                variants
-                                    .into_iter()
-                                    .map(|variant| innermost_type(ctx, fir, *variant))
-                                    .map(|variant| {
-                                        variant.unwrap().set().0.iter().copied().next().unwrap()
-                                    })
-                                    .collect(),
-                            )),
-                            _ => unreachable!(),
-                        }
-                    } else {
-                        todo!()
-                        // Some(Type::new(
-                        //     ty.set()
-                        //         .0
-                        //         .iter()
-                        //         .map(|variant| innermost_type(ctx, fir, *variant))
-                        //         .map(|variant| {
-                        //             variant.unwrap().set().0.iter().copied().next().unwrap()
-                        //         })
-                        //         .collect(),
-                        // ))
-                    }
-                    // if let Kind::TypeReference(r) = referenced_node.kind {
-                    //     innermost_type(ctx, fir, r)
-                    // } else {
-                    //     // FIXME: Remove clone
-                    //     Some(ty.clone())
-                    // }
-                }
-                TypeVariable::Reference(r) => innermost_type(ctx, fir, *r),
-            },
-            None => return None,
-        },
-        None => todo!(),
-    }
+//                         match &referenced_node.kind {
+//                             Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
+//                             Kind::RecordType { .. } => Some(Type::single(
+//                                 origin,
+//                                 RefIdx::Resolved(referenced_node.origin),
+//                             )),
+//                             Kind::UnionType { variants, .. } => Some(Type::new(
+//                                 origin,
+//                                 variants
+//                                     .into_iter()
+//                                     .map(|variant| innermost_type(ctx, fir, *variant))
+//                                     .map(|variant| {
+//                                         variant.unwrap().set().0.iter().copied().next().unwrap()
+//                                     })
+//                                     .collect(),
+//                             )),
+//                             _ => unreachable!(),
+//                         }
+//                     } else {
+//                         todo!()
+//                         // Some(Type::new(
+//                         //     ty.set()
+//                         //         .0
+//                         //         .iter()
+//                         //         .map(|variant| innermost_type(ctx, fir, *variant))
+//                         //         .map(|variant| {
+//                         //             variant.unwrap().set().0.iter().copied().next().unwrap()
+//                         //         })
+//                         //         .collect(),
+//                         // ))
+//                     }
+//                     // if let Kind::TypeReference(r) = referenced_node.kind {
+//                     //     innermost_type(ctx, fir, r)
+//                     // } else {
+//                     //     // FIXME: Remove clone
+//                     //     Some(ty.clone())
+//                     // }
+//                 }
+//                 TypeVariable::Reference(r) => innermost_type(ctx, fir, *r),
+//             },
+//             None => return None,
+//         },
+//         None => todo!(),
+//     }
 
-    //     // if the context contains an entry for `linked_node`, then we use this - otherwise, we simply
-    //     // get the node from the FIR
-    //     let to_lookup = &ctx
-    //         .types
-    //         .get(&linked_node)
-    //         .and_then(|ty| ty.map(|t| t.ref_idx().expect_resolved()))
-    //         .unwrap_or(linked_node);
+//     //     // if the context contains an entry for `linked_node`, then we use this - otherwise, we simply
+//     //     // get the node from the FIR
+//     //     let to_lookup = &ctx
+//     //         .types
+//     //         .get(&linked_node)
+//     //         .and_then(|ty| ty.map(|t| t.ref_idx().expect_resolved()))
+//     //         .unwrap_or(linked_node);
 
-    //     let linked_node = &fir.nodes[to_lookup];
+//     //     let linked_node = &fir.nodes[to_lookup];
 
-    //     let inner_opt = |fir, opt| match opt {
-    //         Some(opt) => innermost_type(ctx, fir, opt),
-    //         None => None,
-    //     };
+//     //     let inner_opt = |fir, opt| match opt {
+//     //         Some(opt) => innermost_type(ctx, fir, opt),
+//     //         None => None,
+//     //     };
 
-    //     match &linked_node.kind {
-    //         // shouldn't we instead stop when we find a TypeVariable::Actual?
-    //         // these are the *only* terminal branches
-    //         Kind::RecordType { .. } | Kind::UnionType { .. } => {
-    //             Some(Type::One(RefIdx::Resolved(linked_node.origin)))
-    //         }
-    //         Kind::Assignment { .. } => None,
-    //         // if a typed value has no specific type, but points to a value, use this as the source of the type
-    //         Kind::TypedValue {
-    //             ty: RefIdx::Unresolved,
-    //             value,
-    //             // can we set `ty` here or not? probably not
-    //             // we need to :(
-    //         } => innermost_type(ctx, fir, *value),
-    //         Kind::Constant(ty)
-    //         | Kind::TypeReference(ty)
-    //         | Kind::TypedValue { ty, .. }
-    //         | Kind::Binding { to: ty }
-    //         | Kind::Instantiation { to: ty, .. }
-    //         | Kind::Call { to: ty, .. }
-    //         | Kind::Conditional { true_block: ty, .. } => innermost_type(ctx, fir, *ty),
-    //         Kind::Function {
-    //             return_type: ty, ..
-    //         }
-    //         | Kind::Return(ty) => inner_opt(fir, *ty),
-    //         Kind::Statements(stmts) => inner_opt(fir, stmts.last().copied()),
-    //         // FIXME: What to do here?
-    //         Kind::Generic { .. } => todo!(),
-    //         Kind::Loop { .. } => todo!(),
-    //         Kind::TypeOffset { .. } => todo!(),
-    //     }
-}
+//     //     match &linked_node.kind {
+//     //         // shouldn't we instead stop when we find a TypeVariable::Actual?
+//     //         // these are the *only* terminal branches
+//     //         Kind::RecordType { .. } | Kind::UnionType { .. } => {
+//     //             Some(Type::One(RefIdx::Resolved(linked_node.origin)))
+//     //         }
+//     //         Kind::Assignment { .. } => None,
+//     //         // if a typed value has no specific type, but points to a value, use this as the source of the type
+//     //         Kind::TypedValue {
+//     //             ty: RefIdx::Unresolved,
+//     //             value,
+//     //             // can we set `ty` here or not? probably not
+//     //             // we need to :(
+//     //         } => innermost_type(ctx, fir, *value),
+//     //         Kind::Constant(ty)
+//     //         | Kind::TypeReference(ty)
+//     //         | Kind::TypedValue { ty, .. }
+//     //         | Kind::Binding { to: ty }
+//     //         | Kind::Instantiation { to: ty, .. }
+//     //         | Kind::Call { to: ty, .. }
+//     //         | Kind::Conditional { true_block: ty, .. } => innermost_type(ctx, fir, *ty),
+//     //         Kind::Function {
+//     //             return_type: ty, ..
+//     //         }
+//     //         | Kind::Return(ty) => inner_opt(fir, *ty),
+//     //         Kind::Statements(stmts) => inner_opt(fir, stmts.last().copied()),
+//     //         // FIXME: What to do here?
+//     //         Kind::Generic { .. } => todo!(),
+//     //         Kind::Loop { .. } => todo!(),
+//     //         Kind::TypeOffset { .. } => todo!(),
+//     //     }
+// }
 
 struct TypeLinkResolver<'ctx> {
     old: &'ctx TypeCtx<TypeLinkMap>,
@@ -267,6 +270,8 @@ struct ResolutionCtx<'ast, 'fir> {
 }
 
 impl<'ctx> TypeLinkResolver<'ctx> {
+    /// Recursively try and resolve a type link within the type context. This will update the given node's type
+    /// within the type context.
     fn resolve_link_v2<'fir>(
         &mut self,
         to_resolve: OriginIdx,
@@ -292,7 +297,7 @@ impl<'ctx> TypeLinkResolver<'ctx> {
     // FIXME: Rename
     // FIXME: Remove ResolutionCtx - too complicated for just one extra parameter
     fn find_end_inner(
-        &self,
+        &mut self,
         ctx: ResolutionCtx,
         mut intermediate_nodes: Vec<OriginIdx>,
     ) -> ControlFlow<ChainEnd, Vec<OriginIdx>> {
@@ -323,8 +328,8 @@ impl<'ctx> TypeLinkResolver<'ctx> {
                 })
             }
             Some(TypeVariable::Union(u)) => {
-                let original_node = fir.nodes[u];
-                let variants = match original_node.kind {
+                let original_node = &fir.nodes[u];
+                let variants = match &original_node.kind {
                     Kind::UnionType { variants, .. } => variants,
                     _ => unreachable!(),
                 };
@@ -344,11 +349,17 @@ impl<'ctx> TypeLinkResolver<'ctx> {
                     final_type: Type::new(*u, variants.collect()),
                 })
             }
-            None => todo!(),
+            // FIXME: Remove None as the type for void types
+            // nothing to do
+            // FIXME: This is invalid
+            None => ControlFlow::Break(ChainEnd {
+                intermediate_nodes,
+                final_type: Type::builtin(HashSet::new()),
+            }),
         }
     }
 
-    fn find_end(&self, ctx: ResolutionCtx) -> ChainEnd {
+    fn find_end(&mut self, ctx: ResolutionCtx) -> ChainEnd {
         let intermediate_nodes = vec![];
 
         match self.find_end_inner(ctx, intermediate_nodes) {
@@ -357,104 +368,102 @@ impl<'ctx> TypeLinkResolver<'ctx> {
         }
     }
 
-    /// Recursively try and resolve a type link within the type context. This will update the given node's type
-    /// within the type context.
-    fn resolve_link(
-        &mut self,
-        fir: &Fir<FlattenData<'_>>,
-        to_resolve: OriginIdx,
-    ) -> Fallible<Error> {
-        // FIXME: Remove mutability, make it more functional
+    // fn resolve_link(
+    //     &mut self,
+    //     fir: &Fir<FlattenData<'_>>,
+    //     to_resolve: OriginIdx,
+    // ) -> Fallible<Error> {
+    //     // FIXME: Remove mutability, make it more functional
 
-        // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
-        // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
-        // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
-        // this returns a TypeRef with which we insert for all the nodes in the chain?
-        // this function should probably be renamed
+    //     // so accumulate type nodes as we go through the chain, then walk everything back setting TypeRef?
+    //     // when we do find a type (so Kind == UnionType | RecordType), we insert the new type in the type map.
+    //     // on each step we should check if we have typemap.contains(node), and if we do, copy the typeref and exit the loop
+    //     // this returns a TypeRef with which we insert for all the nodes in the chain?
+    //     // this function should probably be renamed
 
-        let mut intermediate_nodes = vec![];
-        let mut current = to_resolve;
+    //     let mut intermediate_nodes = vec![];
+    //     let mut current = to_resolve;
 
-        // FIXME: This API does not work with what we've done so far
-        loop {
-            // if any node has not been through "Typer" before, this is an interpreter error
-            let ty = self.old.types.get(&current).unwrap();
+    //     // FIXME: This API does not work with what we've done so far
+    //     loop {
+    //         // if any node has not been through "Typer" before, this is an interpreter error
+    //         let ty = self.old.types.get(&current).unwrap();
 
-            match ty {
-                None => todo!(),
-                Some(TypeVariable::Reference(referenced_ty)) => {
-                    let node = referenced_ty.expect_resolved();
+    //         match ty {
+    //             None => todo!(),
+    //             Some(TypeVariable::Reference(referenced_ty)) => {
+    //                 let node = referenced_ty.expect_resolved();
 
-                    intermediate_nodes.push(node);
-                    current = node;
-                }
-                Some(TypeVariable::Actual(ty)) => {
-                    if ty.set().0.len() == 1 {
-                        // If we have only one type in the typeset, it might be a typereference - if that is the case,
-                        // `innermost_type` it again
-                        // FIXME: This needs more explaining
-                        let referenced_ty = ty.set().0.iter().next().unwrap();
-                        let node = referenced_ty.expect_resolved();
+    //                 intermediate_nodes.push(node);
+    //                 current = node;
+    //             }
+    //             Some(TypeVariable::Actual(ty)) => {
+    //                 if ty.set().0.len() == 1 {
+    //                     // If we have only one type in the typeset, it might be a typereference - if that is the case,
+    //                     // `innermost_type` it again
+    //                     // FIXME: This needs more explaining
+    //                     let referenced_ty = ty.set().0.iter().next().unwrap();
+    //                     let node = referenced_ty.expect_resolved();
 
-                        let kind = fir[&node].kind;
+    //                     let kind = fir[&node].kind;
 
-                        match kind {
-                            Kind::TypeReference(r) => {
-                                intermediate_nodes.push(node);
-                                current = r.expect_resolved();
-                            }
-                            // we found an actual type definition - insert it, break the loop and type
-                            // all the intermediate nodes
-                            Kind::RecordType { fields, .. } => {
-                                let ty = Type::single(node, RefIdx::Resolved(node));
+    //                     match kind {
+    //                         Kind::TypeReference(r) => {
+    //                             intermediate_nodes.push(node);
+    //                             current = r.expect_resolved();
+    //                         }
+    //                         // we found an actual type definition - insert it, break the loop and type
+    //                         // all the intermediate nodes
+    //                         Kind::RecordType { fields, .. } => {
+    //                             let ty = Type::single(node, RefIdx::Resolved(node));
 
-                                self.new.types.new_type(node, ty);
-                            }
-                            Kind::UnionType { variants, .. } => {
-                                todo!()
-                                // FIXME: How do we get the actual type here? we need to go through innermost_type again? :(
-                                // how are types represented in that case? Type::Set { OriginIdx, OriginIdx, OriginIdx }?
-                                // so we need to have these nodes typed already and to get their type from the typemap?
-                                //         variants
-                                //             .into_iter()
-                                //             .map(|variant| innermost_type(ctx, fir, *variant))
-                                //             .map(|variant| {
-                                //                 variant.unwrap().set().0.iter().copied().next().unwrap()
-                                //             })
-                                //             .collect(),
-                            }
-                            _ => unreachable!(),
-                        }
+    //                             self.new.types.new_type(node, ty);
+    //                         }
+    //                         Kind::UnionType { variants, .. } => {
+    //                             todo!()
+    //                             // FIXME: How do we get the actual type here? we need to go through innermost_type again? :(
+    //                             // how are types represented in that case? Type::Set { OriginIdx, OriginIdx, OriginIdx }?
+    //                             // so we need to have these nodes typed already and to get their type from the typemap?
+    //                             //         variants
+    //                             //             .into_iter()
+    //                             //             .map(|variant| innermost_type(ctx, fir, *variant))
+    //                             //             .map(|variant| {
+    //                             //                 variant.unwrap().set().0.iter().copied().next().unwrap()
+    //                             //             })
+    //                             //             .collect(),
+    //                         }
+    //                         _ => unreachable!(),
+    //                     }
 
-                        continue;
-                    }
+    //                     continue;
+    //                 }
 
-                    // FIXME: Remove
-                    break;
-                    // let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
+    //                 // FIXME: Remove
+    //                 break;
+    //                 // let referenced_node = &fir.nodes[&referenced_ty.expect_resolved()];
 
-                    // match &ty.kind {
-                    //     Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
-                    //     Kind::RecordType { .. } => {
-                    //         Some(Type::single(RefIdx::Resolved(referenced_node.origin)))
-                    //     }
-                    //     Kind::UnionType { variants, .. } => Some(Type::new(
-                    //         variants
-                    //             .into_iter()
-                    //             .map(|variant| innermost_type(ctx, fir, *variant))
-                    //             .map(|variant| {
-                    //                 variant.unwrap().set().0.iter().copied().next().unwrap()
-                    //             })
-                    //             .collect(),
-                    //     )),
-                    //     _ => unreachable!(),
-                    // }
-                }
-            }
-        }
+    //                 // match &ty.kind {
+    //                 //     Kind::TypeReference(r) => innermost_type(ctx, fir, *r),
+    //                 //     Kind::RecordType { .. } => {
+    //                 //         Some(Type::single(RefIdx::Resolved(referenced_node.origin)))
+    //                 //     }
+    //                 //     Kind::UnionType { variants, .. } => Some(Type::new(
+    //                 //         variants
+    //                 //             .into_iter()
+    //                 //             .map(|variant| innermost_type(ctx, fir, *variant))
+    //                 //             .map(|variant| {
+    //                 //                 variant.unwrap().set().0.iter().copied().next().unwrap()
+    //                 //             })
+    //                 //             .collect(),
+    //                 //     )),
+    //                 //     _ => unreachable!(),
+    //                 // }
+    //             }
+    //         }
+    //     }
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }
 
 impl<'ctx> Traversal<FlattenData<'_>, Error> for TypeLinkResolver<'ctx> {
@@ -463,6 +472,8 @@ impl<'ctx> Traversal<FlattenData<'_>, Error> for TypeLinkResolver<'ctx> {
         fir: &Fir<FlattenData>,
         node: &Node<FlattenData>,
     ) -> Fallible<Error> {
-        self.resolve_link(fir, node.origin)
+        self.resolve_link_v2(node.origin, fir);
+
+        Ok(())
     }
 }

--- a/typecheck/src/checker.rs
+++ b/typecheck/src/checker.rs
@@ -74,12 +74,8 @@ impl<'ctx> Checker<'ctx> {
             }
             Operator::Unary(Minus) => Type::builtin(numbers.into_iter().collect()),
             // FIXME: These two are ugly as sin - remove the .map call
-            Operator::Comparison(_) => {
-                Type::builtin(comparable[2..].into_iter().map(|r| *r).collect())
-            }
-            Operator::Unary(Not) => {
-                Type::builtin(comparable[..1].into_iter().map(|r| *r).collect())
-            }
+            Operator::Comparison(_) => Type::builtin(comparable[2..].iter().copied().collect()),
+            Operator::Unary(Not) => Type::builtin(comparable[..1].iter().copied().collect()),
         };
 
         let expected_ty = match op.ty() {
@@ -90,7 +86,7 @@ impl<'ctx> Checker<'ctx> {
         };
 
         // FIXME: This API isn't great
-        if valid_union_type.set().contains(&expected_ty.set()) {
+        if valid_union_type.is_superset_of(&expected_ty) {
             Ok(vec![expected_ty; arity])
         } else {
             Err(unexpected_arithmetic_type(

--- a/typecheck/src/lib.rs
+++ b/typecheck/src/lib.rs
@@ -28,7 +28,7 @@ impl TypeSet {
     // TODO: Rename or improve `Type`'s API
     pub fn contains(&self, other: &TypeSet) -> bool {
         // FIXME: This is quite ugly
-        other.0.iter().find(|elt| !self.0.contains(elt)).is_none()
+        !other.0.iter().any(|elt| !self.0.contains(elt))
     }
 }
 
@@ -41,9 +41,8 @@ impl TypeSet {
 pub struct Type(OriginIdx, TypeSet);
 
 impl Type {
-    #[deprecated(note = "needs a new API")]
-    pub fn new(origin: OriginIdx, set: HashSet<RefIdx>) -> Type {
-        Type(origin, TypeSet(set))
+    pub fn union(origin: OriginIdx, variants: impl Iterator<Item = RefIdx>) -> Type {
+        Type(origin, TypeSet(variants.collect()))
     }
 
     pub fn builtin(set: HashSet<RefIdx>) -> Type {
@@ -91,24 +90,6 @@ pub(crate) enum TypeVariable {
     Union(OriginIdx),
     Record(OriginIdx),
     Reference(RefIdx), // specifically we're interested in `type_ctx.type_of(< that refidx >)`
-}
-
-impl TypeVariable {
-    pub fn actual(&self) -> OriginIdx {
-        match self {
-            TypeVariable::Union(a) | TypeVariable::Record(a) => *a,
-            TypeVariable::Reference(r) => unreachable!("unexpected type reference: {r:?}"),
-        }
-    }
-
-    pub fn ref_idx(&self) -> RefIdx {
-        match self {
-            TypeVariable::Union(a) | TypeVariable::Record(a) => {
-                unreachable!("expected reference type, got actual type: {a:?}")
-            }
-            TypeVariable::Reference(r) => *r,
-        }
-    }
 }
 
 type TypeLinkMap = HashMap<OriginIdx, TypeVariable>;

--- a/typecheck/src/lib.rs
+++ b/typecheck/src/lib.rs
@@ -111,7 +111,7 @@ impl TypeVariable {
     }
 }
 
-type TypeLinkMap = HashMap<OriginIdx, Option<TypeVariable>>;
+type TypeLinkMap = HashMap<OriginIdx, TypeVariable>;
 
 // TODO: Make generic over the `types` field? and explain why this is used?
 pub(crate) struct TypeCtx<T> {
@@ -179,6 +179,7 @@ mod tests {
     macro_rules! ast {
         ($($toks:tt)*) => {
             xparser::ast!(
+                type unit;
                 type char;
                 type bool;
                 type int;

--- a/typecheck/src/lib.rs
+++ b/typecheck/src/lib.rs
@@ -521,7 +521,7 @@ mod tests {
                 .collect(),
             ),
         );
-        let single = Type::single(OriginIdx(6), RefIdx::Resolved(OriginIdx(0)));
+        let single = Type::single(OriginIdx(0));
         let empty = Type(OriginIdx(7), TypeSet(HashSet::new()));
 
         // FIXME: Decide on empty's behavior

--- a/typecheck/src/lib.rs
+++ b/typecheck/src/lib.rs
@@ -536,4 +536,18 @@ mod tests {
         assert!(single.can_widen_to(&superset));
         assert!(superset.is_superset_of(&single));
     }
+
+    #[test]
+    fn nullable_union_type() {
+        let ast = ast! {
+            type Nil;
+            type Nullable = int | Nil;
+
+            func nil_unit() -> Nullable { Nil }
+            func nil_just(i: int) -> Nullable { i }
+        };
+        let fir = fir!(ast).type_check();
+
+        assert!(fir.is_ok());
+    }
 }

--- a/typecheck/src/primitives.rs
+++ b/typecheck/src/primitives.rs
@@ -21,6 +21,9 @@ struct PrimitiveTypeCtx {
 /// This is the finalized version of [`PrimitiveTypeCtx`] - a version which only has
 /// valid [`OriginIdx`], or otherwise it will not be returned, and an [`Error`] will
 /// be present instead
+// FIXME: Does this need a `void` type? How do we encode it? How is it different from an empty record type,
+// which at the moment is how we flatten empty types like `type Empty;`
+#[derive(Clone)]
 pub struct PrimitiveTypes {
     pub(crate) bool_type: OriginIdx,
     pub(crate) char_type: OriginIdx,

--- a/typecheck/src/primitives.rs
+++ b/typecheck/src/primitives.rs
@@ -22,8 +22,6 @@ struct PrimitiveTypeCtx {
 /// This is the finalized version of [`PrimitiveTypeCtx`] - a version which only has
 /// valid [`OriginIdx`], or otherwise it will not be returned, and an [`Error`] will
 /// be present instead
-// FIXME: Does this need a `void` type? How do we encode it? How is it different from an empty record type,
-// which at the moment is how we flatten empty types like `type Empty;`
 #[derive(Clone)]
 pub struct PrimitiveTypes {
     pub(crate) unit_type: OriginIdx,

--- a/typecheck/src/typemap.rs
+++ b/typecheck/src/typemap.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+use fir::OriginIdx;
+
+use crate::Type;
+
+// FIXME: Fix documentation
+// typer is going to create a linked list of types
+// actual is going to flatten that linked list into a "multikey-map", TypeMap
+
+// so the role of Actual is to take a Map<OriginIdx, TypeRef>
+// and turn it into a TypeMap
+
+// so, typer is Fir -> Map<OriginIdx, TypeRef>
+// actual is Map<OriginIdx, TypeRef> -> TypeMap,
+// checker is TypeMap -> Result<Fir, Error>
+
+// do we do something like TypeCtx<LinkedTypeMap> ? and then TypeCtx<TypeMap>
+// and Actual is TypeCtx<LinkedTypeMap> -> TypeCtx<TypeMap>?
+
+/// A strongly typed reference to a type node - `Kind::UnionType` or `Kind::RecordType` only
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct TypeRef(OriginIdx);
+
+// FIXME: These two are not needed?
+// FIXME: Should we use phantom types here?
+pub struct UnionType(OriginIdx);
+pub struct RecordType(OriginIdx);
+
+impl TypeRef {
+    pub fn union(UnionType(node): UnionType) -> TypeRef {
+        TypeRef(node)
+    }
+
+    pub fn record(RecordType(node): RecordType) -> TypeRef {
+        TypeRef(node)
+    }
+}
+
+pub struct TypeMap {
+    nodes: HashMap<OriginIdx, TypeRef>,
+    types: HashMap<TypeRef, Type>,
+}
+
+impl TypeMap {
+    pub fn new() -> TypeMap {
+        TypeMap {
+            nodes: HashMap::new(),
+            types: HashMap::new(),
+        }
+    }
+
+    pub fn type_of(&self, node: OriginIdx) -> Option<&Type> {
+        self.nodes
+            .get(&node)
+            .and_then(|ty_ref| self.types.get(ty_ref))
+    }
+
+    /// Insert a new type into the typemap
+    pub fn new_type(&mut self, origin: OriginIdx, ty: Type) -> TypeRef {
+        let ty_ref = TypeRef(origin);
+        // FIXME:
+        self.types.insert(ty_ref, ty).unwrap();
+
+        ty_ref
+    }
+
+    pub fn insert(&mut self, node: OriginIdx, tyref: TypeRef) {
+        // FIXME:
+        self.nodes.insert(node, tyref).unwrap();
+    }
+}

--- a/typecheck/src/typemap.rs
+++ b/typecheck/src/typemap.rs
@@ -18,7 +18,6 @@ use crate::Type;
 // do we do something like TypeCtx<LinkedTypeMap> ? and then TypeCtx<TypeMap>
 // and Actual is TypeCtx<LinkedTypeMap> -> TypeCtx<TypeMap>?
 
-/// A strongly typed reference to a type node - `Kind::UnionType` or `Kind::RecordType` only
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct TypeRef(pub(crate) OriginIdx); // FIXME: Remove vis?
 
@@ -26,10 +25,7 @@ pub struct TypeRef(pub(crate) OriginIdx); // FIXME: Remove vis?
 pub struct TypeMap {
     nodes: HashMap<OriginIdx, TypeRef>,
     // FIXME: Remove?
-    pub(crate) types: HashMap<
-        TypeRef,
-        Type, /* FIXME: We should store the OriginIdx here as well probably */
-    >,
+    pub(crate) types: HashMap<TypeRef, Type>,
 }
 
 impl TypeMap {
@@ -60,7 +56,7 @@ impl TypeMap {
     }
 
     pub fn insert(&mut self, node: OriginIdx, tyref: TypeRef) {
-        // FIXME:
+        // FIXME: Is that okay?
         self.nodes.insert(node, tyref);
     }
 }

--- a/typecheck/src/typemap.rs
+++ b/typecheck/src/typemap.rs
@@ -44,6 +44,10 @@ impl TypeMap {
         self.nodes
             .get(&node)
             .and_then(|ty_ref| self.types.get(ty_ref))
+            // in case that we are directly looking at the type's definition and not a reference.
+            // this happens when dealing with inline type variables, such as union-types defined
+            // in a function's return type.
+            .or_else(|| self.types.get(&TypeRef(node)))
     }
 
     /// Insert a new type into the typemap

--- a/typecheck/src/typemap.rs
+++ b/typecheck/src/typemap.rs
@@ -19,27 +19,14 @@ use crate::Type;
 // and Actual is TypeCtx<LinkedTypeMap> -> TypeCtx<TypeMap>?
 
 /// A strongly typed reference to a type node - `Kind::UnionType` or `Kind::RecordType` only
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
-pub struct TypeRef(OriginIdx);
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub struct TypeRef(pub(crate) OriginIdx); // FIXME: Remove vis?
 
-// FIXME: These two are not needed?
-// FIXME: Should we use phantom types here?
-pub struct UnionType(OriginIdx);
-pub struct RecordType(OriginIdx);
-
-impl TypeRef {
-    pub fn union(UnionType(node): UnionType) -> TypeRef {
-        TypeRef(node)
-    }
-
-    pub fn record(RecordType(node): RecordType) -> TypeRef {
-        TypeRef(node)
-    }
-}
-
+#[derive(Debug)]
 pub struct TypeMap {
     nodes: HashMap<OriginIdx, TypeRef>,
-    types: HashMap<
+    // FIXME: Remove?
+    pub(crate) types: HashMap<
         TypeRef,
         Type, /* FIXME: We should store the OriginIdx here as well probably */
     >,

--- a/typecheck/src/typemap.rs
+++ b/typecheck/src/typemap.rs
@@ -39,7 +39,10 @@ impl TypeRef {
 
 pub struct TypeMap {
     nodes: HashMap<OriginIdx, TypeRef>,
-    types: HashMap<TypeRef, Type>,
+    types: HashMap<
+        TypeRef,
+        Type, /* FIXME: We should store the OriginIdx here as well probably */
+    >,
 }
 
 impl TypeMap {
@@ -57,16 +60,16 @@ impl TypeMap {
     }
 
     /// Insert a new type into the typemap
-    pub fn new_type(&mut self, origin: OriginIdx, ty: Type) -> TypeRef {
-        let ty_ref = TypeRef(origin);
-        // FIXME:
-        self.types.insert(ty_ref, ty).unwrap();
+    pub fn new_type(&mut self, ty: Type) -> TypeRef {
+        let ty_ref = TypeRef(ty.0);
+        // FIXME: Is it actually okay to ignore if the type existed or not?
+        self.types.insert(ty_ref, ty);
 
         ty_ref
     }
 
     pub fn insert(&mut self, node: OriginIdx, tyref: TypeRef) {
         // FIXME:
-        self.nodes.insert(node, tyref).unwrap();
+        self.nodes.insert(node, tyref);
     }
 }

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -6,7 +6,7 @@ use error::Error;
 use fir::{Kind, Mapper, Node, OriginIdx, RefIdx};
 use flatten::FlattenData;
 
-use crate::{Type, TypeCtx, TypeLinkMap, TypeVariable};
+use crate::{TypeCtx, TypeLinkMap, TypeVariable};
 
 /// This pass takes care of "typing" each node in the [`Fir`], but to a non-terminal type. More explanation can be found
 /// in the documentation for [`Typer::ty`].
@@ -125,11 +125,7 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
         generics: Vec<RefIdx>,
         fields: Vec<RefIdx>,
     ) -> Result<Node<FlattenData<'ast>>, Error> {
-        self.assign_type(
-            origin,
-            // this is too complicated
-            Some(TypeVariable::Actual(Type::single(RefIdx::Resolved(origin)))),
-        );
+        self.assign_type(origin, Some(TypeVariable::Record(origin)));
 
         // and we return the same node since this is mapper
         Ok(Node {
@@ -146,12 +142,7 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
         generics: Vec<RefIdx>,
         variants: Vec<RefIdx>,
     ) -> Result<Node<FlattenData<'ast>>, Error> {
-        self.assign_type(
-            origin,
-            Some(TypeVariable::Actual(Type::new(
-                variants.iter().copied().collect(),
-            ))),
-        );
+        self.assign_type(origin, Some(TypeVariable::Union(origin)));
 
         Ok(Node {
             data,


### PR DESCRIPTION
- [wip]: Start working on type var interpreter. Bring over UnionType from FIR
- [wip]: Go further with the typelevel interpreter
- [wip] it compiles
- [wip]: Improve errors and API
- wip: Add proper handling of Kind::UnionType
- [wip] almost there
- [wip] it fucken works ~ ! ! ~
- typecheck: Start adding TypeMap data structure
- typecheck: Start making TypeCtx generic
