### PR TITLE
Fix relationship between `Kind::Binding` and `Kind::TypedValue`

### DIFF
--- a/debug-fir/src/lib.rs
+++ b/debug-fir/src/lib.rs
@@ -107,9 +107,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
         let content = match kind {
             Kind::Constant(r) => format!("0: {}", fmt_r(r)),
             Kind::TypeReference(r) => format!("0: {}", fmt_r(r)),
-            Kind::NodeRef { value, ty } => {
-                format!("value: {}\n\t\tty: {}", fmt_r(value), fmt_r(ty))
-            }
+            Kind::NodeRef(to) => format!("0: {}", fmt_r(to)),
             Kind::Generic { default } => format!("default: {}", fmt_opt(default)),
             Kind::RecordType { generics, fields } => format!(
                 "generics: {}\n\t\tfields: {}",

--- a/debug-fir/src/lib.rs
+++ b/debug-fir/src/lib.rs
@@ -88,7 +88,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
         let str = match kind {
             Kind::Constant(_) => "Constant".blue(),
             Kind::TypeReference(_) => "TypeReference".blue(),
-            Kind::TypedValue { .. } => "TypedValue".blue(),
+            Kind::NodeRef { .. } => "TypedValue".blue(),
             Kind::Generic { .. } => "Generic".blue(),
             Kind::RecordType { .. } => "RecordType".blue(),
             Kind::UnionType { .. } => "UnionType".blue(),
@@ -107,7 +107,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
         let content = match kind {
             Kind::Constant(r) => format!("0: {}", fmt_r(r)),
             Kind::TypeReference(r) => format!("0: {}", fmt_r(r)),
-            Kind::TypedValue { value, ty } => {
+            Kind::NodeRef { value, ty } => {
                 format!("value: {}\n\t\tty: {}", fmt_r(value), fmt_r(ty))
             }
             Kind::Generic { default } => format!("default: {}", fmt_opt(default)),

--- a/debug-fir/src/lib.rs
+++ b/debug-fir/src/lib.rs
@@ -131,7 +131,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
                 fmt_opt(return_type),
                 fmt_opt(block)
             ),
-            Kind::Binding { to } => format!("to: {}", fmt_r(to)),
+            Kind::Binding { to, ty } => format!("to: {}\n\t\tty: {}", fmt_opt(to), fmt_r(ty)),
             Kind::Assignment { to, from } => {
                 format!("to: {}\n\t\tfrom: {}", fmt_r(to), fmt_r(from))
             }

--- a/debug-fir/src/lib.rs
+++ b/debug-fir/src/lib.rs
@@ -88,7 +88,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
         let str = match kind {
             Kind::Constant(_) => "Constant".blue(),
             Kind::TypeReference(_) => "TypeReference".blue(),
-            Kind::NodeRef { .. } => "TypedValue".blue(),
+            Kind::NodeRef { .. } => "NodeRef".blue(),
             Kind::Generic { .. } => "Generic".blue(),
             Kind::RecordType { .. } => "RecordType".blue(),
             Kind::UnionType { .. } => "UnionType".blue(),

--- a/debug-fir/src/lib.rs
+++ b/debug-fir/src/lib.rs
@@ -131,7 +131,7 @@ impl<T, F: Fn(&T) -> String> FirDebug<T, F> {
                 fmt_opt(return_type),
                 fmt_opt(block)
             ),
-            Kind::Binding { to, ty } => format!("to: {}\n\t\tty: {}", fmt_opt(to), fmt_r(ty)),
+            Kind::Binding { to, ty } => format!("to: {}\n\t\tty: {}", fmt_opt(to), fmt_opt(ty)),
             Kind::Assignment { to, from } => {
                 format!("to: {}\n\t\tfrom: {}", fmt_r(to), fmt_r(from))
             }

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -107,7 +107,7 @@ impl<T: Debug> Fir<T> {
                 }
                 Kind::Binding { to: _, ty } => {
                     // `to` can point to anything, correct?
-                    check!(ty => Kind::TypeReference(_) | Kind::UnionType { .. }, node)
+                    check!(ty => Some(Kind::TypeReference(_) | Kind::UnionType { .. }), node)
                 }
                 Kind::Assignment { to, from: _ } => {
                     check!(to => Kind::NodeRef { .. } | Kind::Binding { .. }, node);

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -63,14 +63,14 @@ impl<T: Debug> Fir<T> {
                 // point to an if-else expression. Basically, to anything that's an expression actually.
                 // Should we split the fir::Kind into fir::Kind::Stmt and fir::Kind::Expr? Or does that not make sense?
                 Kind::Constant(r) => check!(r => Kind::RecordType { .. }, node),
-                Kind::TypedValue { value, ty } => {
+                Kind::NodeRef { value, ty } => {
                     // FIXME: Is pointing to `Type` here valid?
                     check!(ty => Kind::UnionType { .. } | Kind::RecordType { .. } | Kind::TypeReference(_), node);
                     // `value` can link to basically anything
                     check!(value => Kind::Call { .. }
                         | Kind::Constant(_)
                         | Kind::Instantiation { .. }
-                        | Kind::TypedValue { .. }
+                        | Kind::NodeRef { .. }
                         | Kind::Binding { .. }
                         | Kind::RecordType { .. } // for empty types // FIXME: Is that allowed?
                         , node);
@@ -98,7 +98,7 @@ impl<T: Debug> Fir<T> {
                 } => {
                     check!(to => Kind::Function { .. }, node);
                     check!(@generics => Kind::TypeReference { .. }, node);
-                    check!(@args => Kind::TypedValue { .. } | Kind::Constant(_) | Kind::Call { .. }, node);
+                    check!(@args => Kind::NodeRef { .. } | Kind::Constant(_) | Kind::Call { .. }, node);
                 }
                 Kind::RecordType {
                     generics,
@@ -118,7 +118,7 @@ impl<T: Debug> Fir<T> {
                     // FIXME: Check `to` as well
                 }
                 Kind::Assignment { to, from: _ } => {
-                    check!(to => Kind::TypedValue { .. } | Kind::Binding { .. }, node);
+                    check!(to => Kind::NodeRef { .. } | Kind::Binding { .. }, node);
                     // FIXME: Check `from` as well
                 }
                 Kind::Instantiation {

--- a/fir/src/checks.rs
+++ b/fir/src/checks.rs
@@ -63,17 +63,8 @@ impl<T: Debug> Fir<T> {
                 // point to an if-else expression. Basically, to anything that's an expression actually.
                 // Should we split the fir::Kind into fir::Kind::Stmt and fir::Kind::Expr? Or does that not make sense?
                 Kind::Constant(r) => check!(r => Kind::RecordType { .. }, node),
-                Kind::NodeRef { value, ty } => {
-                    // FIXME: Is pointing to `Type` here valid?
-                    check!(ty => Kind::UnionType { .. } | Kind::RecordType { .. } | Kind::TypeReference(_), node);
-                    // `value` can link to basically anything
-                    check!(value => Kind::Call { .. }
-                        | Kind::Constant(_)
-                        | Kind::Instantiation { .. }
-                        | Kind::NodeRef { .. }
-                        | Kind::Binding { .. }
-                        | Kind::RecordType { .. } // for empty types // FIXME: Is that allowed?
-                        , node);
+                Kind::NodeRef(_to) => {
+                    // `to` can link to basically anything, so there is nothing to do
                 }
                 // FIXME: Is that okay?
                 Kind::TypeReference(to) => check!(to => Kind::RecordType { .. } | Kind::UnionType { .. } |  Kind::Generic { .. } | Kind::TypeReference(_), node),

--- a/fir/src/iter/mapper.rs
+++ b/fir/src/iter/mapper.rs
@@ -92,11 +92,17 @@ pub trait Mapper<T, U: From<T>, E> {
         })
     }
 
-    fn map_binding(&mut self, data: T, origin: OriginIdx, to: RefIdx) -> Result<Node<U>, E> {
+    fn map_binding(
+        &mut self,
+        data: T,
+        origin: OriginIdx,
+        to: Option<RefIdx>,
+        ty: RefIdx,
+    ) -> Result<Node<U>, E> {
         Ok(Node {
             data: U::from(data),
             origin,
-            kind: Kind::Binding { to },
+            kind: Kind::Binding { to, ty },
         })
     }
 
@@ -239,7 +245,7 @@ pub trait Mapper<T, U: From<T>, E> {
                 return_type,
                 block,
             } => self.map_function(node.data, node.origin, generics, args, return_type, block),
-            Kind::Binding { to } => self.map_binding(node.data, node.origin, to),
+            Kind::Binding { to, ty } => self.map_binding(node.data, node.origin, to, ty),
             Kind::Instantiation {
                 to,
                 generics,

--- a/fir/src/iter/mapper.rs
+++ b/fir/src/iter/mapper.rs
@@ -97,7 +97,7 @@ pub trait Mapper<T, U: From<T>, E> {
         data: T,
         origin: OriginIdx,
         to: Option<RefIdx>,
-        ty: RefIdx,
+        ty: Option<RefIdx>,
     ) -> Result<Node<U>, E> {
         Ok(Node {
             data: U::from(data),

--- a/fir/src/iter/mapper.rs
+++ b/fir/src/iter/mapper.rs
@@ -22,17 +22,11 @@ pub trait Mapper<T, U: From<T>, E> {
         })
     }
 
-    fn map_typed_value(
-        &mut self,
-        data: T,
-        origin: OriginIdx,
-        value: RefIdx,
-        ty: RefIdx,
-    ) -> Result<Node<U>, E> {
+    fn map_node_ref(&mut self, data: T, origin: OriginIdx, to: RefIdx) -> Result<Node<U>, E> {
         Ok(Node {
             data: U::from(data),
             origin,
-            kind: Kind::NodeRef { value, ty },
+            kind: Kind::NodeRef(to),
         })
     }
 
@@ -231,7 +225,7 @@ pub trait Mapper<T, U: From<T>, E> {
         match node.kind {
             Kind::Constant(c) => self.map_constant(node.data, node.origin, c),
             Kind::TypeReference(r) => self.map_type_reference(node.data, node.origin, r),
-            Kind::NodeRef { value, ty } => self.map_typed_value(node.data, node.origin, value, ty),
+            Kind::NodeRef(to) => self.map_node_ref(node.data, node.origin, to),
             Kind::Generic { default } => self.map_generic(node.data, node.origin, default),
             Kind::RecordType { generics, fields } => {
                 self.map_record_type(node.data, node.origin, generics, fields)

--- a/fir/src/iter/mapper.rs
+++ b/fir/src/iter/mapper.rs
@@ -32,7 +32,7 @@ pub trait Mapper<T, U: From<T>, E> {
         Ok(Node {
             data: U::from(data),
             origin,
-            kind: Kind::TypedValue { value, ty },
+            kind: Kind::NodeRef { value, ty },
         })
     }
 
@@ -231,9 +231,7 @@ pub trait Mapper<T, U: From<T>, E> {
         match node.kind {
             Kind::Constant(c) => self.map_constant(node.data, node.origin, c),
             Kind::TypeReference(r) => self.map_type_reference(node.data, node.origin, r),
-            Kind::TypedValue { value, ty } => {
-                self.map_typed_value(node.data, node.origin, value, ty)
-            }
+            Kind::NodeRef { value, ty } => self.map_typed_value(node.data, node.origin, value, ty),
             Kind::Generic { default } => self.map_generic(node.data, node.origin, default),
             Kind::RecordType { generics, fields } => {
                 self.map_record_type(node.data, node.origin, generics, fields)

--- a/fir/src/iter/multi_mapper.rs
+++ b/fir/src/iter/multi_mapper.rs
@@ -32,17 +32,11 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         }])
     }
 
-    fn map_typed_value(
-        &mut self,
-        _data: T,
-        origin: OriginIdx,
-        value: RefIdx,
-        ty: RefIdx,
-    ) -> Result<Vec<Node<U>>, E> {
+    fn map_node_ref(&mut self, _data: T, origin: OriginIdx, to: RefIdx) -> Result<Vec<Node<U>>, E> {
         Ok(vec![Node {
             data: U::from(_data),
             origin,
-            kind: Kind::NodeRef { value, ty },
+            kind: Kind::NodeRef(to),
         }])
     }
 
@@ -241,7 +235,7 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         match node.kind {
             Kind::Constant(c) => self.map_constant(node.data, node.origin, c),
             Kind::TypeReference(r) => self.map_type_reference(node.data, node.origin, r),
-            Kind::NodeRef { value, ty } => self.map_typed_value(node.data, node.origin, value, ty),
+            Kind::NodeRef(to) => self.map_node_ref(node.data, node.origin, to),
             Kind::Generic { default } => self.map_generic(node.data, node.origin, default),
             Kind::RecordType { generics, fields } => {
                 self.map_record_type(node.data, node.origin, generics, fields)

--- a/fir/src/iter/multi_mapper.rs
+++ b/fir/src/iter/multi_mapper.rs
@@ -102,11 +102,17 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         }])
     }
 
-    fn map_binding(&mut self, _data: T, origin: OriginIdx, to: RefIdx) -> Result<Vec<Node<U>>, E> {
+    fn map_binding(
+        &mut self,
+        _data: T,
+        origin: OriginIdx,
+        to: Option<RefIdx>,
+        ty: RefIdx,
+    ) -> Result<Vec<Node<U>>, E> {
         Ok(vec![Node {
             data: U::from(_data),
             origin,
-            kind: Kind::Binding { to },
+            kind: Kind::Binding { to, ty },
         }])
     }
 
@@ -249,7 +255,7 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
                 return_type,
                 block,
             } => self.map_function(node.data, node.origin, generics, args, return_type, block),
-            Kind::Binding { to } => self.map_binding(node.data, node.origin, to),
+            Kind::Binding { to, ty } => self.map_binding(node.data, node.origin, to, ty),
             Kind::Instantiation {
                 to,
                 generics,

--- a/fir/src/iter/multi_mapper.rs
+++ b/fir/src/iter/multi_mapper.rs
@@ -107,7 +107,7 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         _data: T,
         origin: OriginIdx,
         to: Option<RefIdx>,
-        ty: RefIdx,
+        ty: Option<RefIdx>,
     ) -> Result<Vec<Node<U>>, E> {
         Ok(vec![Node {
             data: U::from(_data),

--- a/fir/src/iter/multi_mapper.rs
+++ b/fir/src/iter/multi_mapper.rs
@@ -42,7 +42,7 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         Ok(vec![Node {
             data: U::from(_data),
             origin,
-            kind: Kind::TypedValue { value, ty },
+            kind: Kind::NodeRef { value, ty },
         }])
     }
 
@@ -241,9 +241,7 @@ pub trait MultiMapper<T, U: Default + From<T>, E> {
         match node.kind {
             Kind::Constant(c) => self.map_constant(node.data, node.origin, c),
             Kind::TypeReference(r) => self.map_type_reference(node.data, node.origin, r),
-            Kind::TypedValue { value, ty } => {
-                self.map_typed_value(node.data, node.origin, value, ty)
-            }
+            Kind::NodeRef { value, ty } => self.map_typed_value(node.data, node.origin, value, ty),
             Kind::Generic { default } => self.map_generic(node.data, node.origin, default),
             Kind::RecordType { generics, fields } => {
                 self.map_record_type(node.data, node.origin, generics, fields)

--- a/fir/src/iter/traverse.rs
+++ b/fir/src/iter/traverse.rs
@@ -76,7 +76,7 @@ pub trait Traversal<T, E> {
         _fir: &Fir<T>,
         _node: &Node<T>,
         _to: &Option<RefIdx>,
-        ty: &RefIdx,
+        ty: &Option<RefIdx>,
     ) -> Fallible<E> {
         Ok(())
     }

--- a/fir/src/iter/traverse.rs
+++ b/fir/src/iter/traverse.rs
@@ -21,12 +21,11 @@ pub trait Traversal<T, E> {
         Ok(())
     }
 
-    fn traverse_typed_value(
+    fn traverse_node_reference(
         &mut self,
         _fir: &Fir<T>,
         _node: &Node<T>,
-        _value: &RefIdx,
-        _ty: &RefIdx,
+        _to: &RefIdx,
     ) -> Fallible<E> {
         Ok(())
     }
@@ -161,7 +160,7 @@ pub trait Traversal<T, E> {
         match &node.kind {
             Kind::Constant(c) => self.traverse_constant(fir, node, c),
             Kind::TypeReference(r) => self.traverse_type_reference(fir, node, r),
-            Kind::NodeRef { value, ty } => self.traverse_typed_value(fir, node, value, ty),
+            Kind::NodeRef(to) => self.traverse_node_reference(fir, node, to),
             Kind::Generic { default } => self.traverse_generic(fir, node, default),
             Kind::RecordType { generics, fields } => {
                 self.traverse_record_type(fir, node, generics, fields)

--- a/fir/src/iter/traverse.rs
+++ b/fir/src/iter/traverse.rs
@@ -161,7 +161,7 @@ pub trait Traversal<T, E> {
         match &node.kind {
             Kind::Constant(c) => self.traverse_constant(fir, node, c),
             Kind::TypeReference(r) => self.traverse_type_reference(fir, node, r),
-            Kind::TypedValue { value, ty } => self.traverse_typed_value(fir, node, value, ty),
+            Kind::NodeRef { value, ty } => self.traverse_typed_value(fir, node, value, ty),
             Kind::Generic { default } => self.traverse_generic(fir, node, default),
             Kind::RecordType { generics, fields } => {
                 self.traverse_record_type(fir, node, generics, fields)

--- a/fir/src/iter/traverse.rs
+++ b/fir/src/iter/traverse.rs
@@ -71,7 +71,13 @@ pub trait Traversal<T, E> {
         Ok(())
     }
 
-    fn traverse_binding(&mut self, _fir: &Fir<T>, _node: &Node<T>, _to: &RefIdx) -> Fallible<E> {
+    fn traverse_binding(
+        &mut self,
+        _fir: &Fir<T>,
+        _node: &Node<T>,
+        _to: &Option<RefIdx>,
+        ty: &RefIdx,
+    ) -> Fallible<E> {
         Ok(())
     }
 
@@ -175,7 +181,7 @@ pub trait Traversal<T, E> {
                 block,
             } => self.traverse_function(fir, node, generics, args, return_type, block),
             Kind::Assignment { to, from } => self.traverse_assignment(fir, node, to, from),
-            Kind::Binding { to } => self.traverse_binding(fir, node, to),
+            Kind::Binding { to, ty } => self.traverse_binding(fir, node, to, ty),
             Kind::Instantiation {
                 to,
                 generics,

--- a/fir/src/iter/traverse.rs
+++ b/fir/src/iter/traverse.rs
@@ -76,7 +76,7 @@ pub trait Traversal<T, E> {
         _fir: &Fir<T>,
         _node: &Node<T>,
         _to: &Option<RefIdx>,
-        ty: &Option<RefIdx>,
+        _ty: &Option<RefIdx>,
     ) -> Fallible<E> {
         Ok(())
     }

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -213,6 +213,7 @@ pub enum Kind {
         // TODO: Add a `ty` field
         // TODO: Should this be Option<RefIdx> actually? A binding can exist without a value,
         // e.g. an argument in a function *is* a binding but does not have a value until runtime?
+        // FIXME: This should definitely be a Option<RefIdx>
         to: RefIdx, // to Kind::{TypedValue, Instantiation, any expr?},
     },
     Assignment {
@@ -246,12 +247,11 @@ pub enum Kind {
     Return(Option<RefIdx>),  // to any kind
     // TODO: Rework this into a ValueReference or something?
     // TODO: Does this need a `ty` field?
-    // TODO: Can we actually remove ValueRef entirely? since we can just have a RefIdx(Binding)
-    /// Reference to another node, possibly unresolved
-    NodeRef {
-        value: RefIdx, // to Kind::{Call, Instantiation, TypedValue, Constant}
-        ty: RefIdx,    // to Kind::Type
-    },
+    // TODO: Can we actually remove ValueRef entirely? since we can just have a RefIdx(Binding) - no, we can't
+    /// Reference to another node, possibly unresolved. This is the same as a
+    /// raw [`RefIdx`], but is useful if you need an actual node to manipulate and modify.
+    /// This means that you can handle this node as you would a regular [`RefIdx`]
+    NodeRef(RefIdx),
 }
 
 impl<T> Index<&RefIdx> for Fir<T> {

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -214,7 +214,8 @@ pub enum Kind {
         // TODO: Should this be Option<RefIdx> actually? A binding can exist without a value,
         // e.g. an argument in a function *is* a binding but does not have a value until runtime?
         // FIXME: This should definitely be a Option<RefIdx>
-        to: RefIdx, // to Kind::{TypedValue, Instantiation, any expr?},
+        to: Option<RefIdx>, // to Kind::{TypedValue, Instantiation, any expr?},
+        ty: RefIdx,
     },
     Assignment {
         to: RefIdx,   // to Kind::TypedValue

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -179,10 +179,6 @@ pub enum Kind {
     // TODO: Do we want newtype patterns so that references can only point to certain types? i.e TypeRef(RefIdx)
     Constant(RefIdx), // to Kind::TypeReference, // FIXME: Is TypeReference the play? Yes, but really that way?
     TypeReference(RefIdx), // to Kind::{Type, Generic}
-    TypedValue {
-        value: RefIdx, // to Kind::{Call, Instantiation, TypedValue, Constant}
-        ty: RefIdx,    // to Kind::Type
-    },
     Generic {
         default: Option<RefIdx>, // to Kind::Type
     },
@@ -203,6 +199,20 @@ pub enum Kind {
     /// A binding is immutable, however there can be multiple bindings. Assigning to a mutable
     /// variable can be thought of a second binding.
     Binding {
+        // TODO: Document that the Binding kind is a declaration point
+        //
+        // where b = 15;
+        //       ^
+        //
+        // /* or */
+        //
+        // foo(a: int)
+        //     ^^^^^^
+        //
+        // is that true?
+        // TODO: Add a `ty` field
+        // TODO: Should this be Option<RefIdx> actually? A binding can exist without a value,
+        // e.g. an argument in a function *is* a binding but does not have a value until runtime?
         to: RefIdx, // to Kind::{TypedValue, Instantiation, any expr?},
     },
     Assignment {
@@ -234,6 +244,14 @@ pub enum Kind {
     },
     Statements(Vec<RefIdx>), // to any kind
     Return(Option<RefIdx>),  // to any kind
+    // TODO: Rework this into a ValueReference or something?
+    // TODO: Does this need a `ty` field?
+    // TODO: Can we actually remove ValueRef entirely? since we can just have a RefIdx(Binding)
+    /// Reference to another node, possibly unresolved
+    NodeRef {
+        value: RefIdx, // to Kind::{Call, Instantiation, TypedValue, Constant}
+        ty: RefIdx,    // to Kind::Type
+    },
 }
 
 impl<T> Index<&RefIdx> for Fir<T> {

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -215,7 +215,7 @@ pub enum Kind {
         // e.g. an argument in a function *is* a binding but does not have a value until runtime?
         // FIXME: This should definitely be a Option<RefIdx>
         to: Option<RefIdx>, // to Kind::{TypedValue, Instantiation, any expr?},
-        ty: RefIdx,
+        ty: Option<RefIdx>,
     },
     Assignment {
         to: RefIdx,   // to Kind::TypedValue

--- a/fir/src/lib.rs
+++ b/fir/src/lib.rs
@@ -196,26 +196,20 @@ pub enum Kind {
         return_type: Option<RefIdx>, // to Kind::Type,
         block: Option<RefIdx>,       // to Kind::Statements
     },
-    /// A binding is immutable, however there can be multiple bindings. Assigning to a mutable
-    /// variable can be thought of a second binding.
+    /// A binding is an immutable declaration point, with or without a value and with or without a specified type.
+    /// In the following code example, both the variable declaration and function argument are bindings.
+    /// ```ignore
+    /// where b = 15;
+    ///       ^
+    ///
+    /// /* or */
+    ///
+    /// foo(a: int)
+    ///     ^^^^^^
+    /// ```
     Binding {
-        // TODO: Document that the Binding kind is a declaration point
-        //
-        // where b = 15;
-        //       ^
-        //
-        // /* or */
-        //
-        // foo(a: int)
-        //     ^^^^^^
-        //
-        // is that true?
-        // TODO: Add a `ty` field
-        // TODO: Should this be Option<RefIdx> actually? A binding can exist without a value,
-        // e.g. an argument in a function *is* a binding but does not have a value until runtime?
-        // FIXME: This should definitely be a Option<RefIdx>
         to: Option<RefIdx>, // to Kind::{TypedValue, Instantiation, any expr?},
-        ty: Option<RefIdx>,
+        ty: Option<RefIdx>, // to Kind::{TypeReference, UnionType}
     },
     Assignment {
         to: RefIdx,   // to Kind::TypedValue
@@ -246,9 +240,6 @@ pub enum Kind {
     },
     Statements(Vec<RefIdx>), // to any kind
     Return(Option<RefIdx>),  // to any kind
-    // TODO: Rework this into a ValueReference or something?
-    // TODO: Does this need a `ty` field?
-    // TODO: Can we actually remove ValueRef entirely? since we can just have a RefIdx(Binding) - no, we can't
     /// Reference to another node, possibly unresolved. This is the same as a
     /// raw [`RefIdx`], but is useful if you need an actual node to manipulate and modify.
     /// This means that you can handle this node as you would a regular [`RefIdx`]

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -215,11 +215,13 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
     fn fire_binding(
         &mut self,
         node: &Node<FlattenData<'_>>,
-        to: &RefIdx,
+        to: &Option<RefIdx>,
     ) -> ControlFlow<EarlyExit> {
-        self.fire_node_ref(to)?;
+        if let Some(to) = to {
+            self.fire_node_ref(to)?;
 
-        self.gc.transfer(to, node.origin);
+            self.gc.transfer(to, node.origin);
+        }
 
         KeepGoing
     }
@@ -287,7 +289,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 args,
                 .. /* FIXME: Generics should be empty at this point */
             } => self.fire_call( node, to, args),
-            Kind::Binding { to } => self.fire_binding(node, to),
+            Kind::Binding { to, .. } => self.fire_binding(node, to),
             Kind::NodeRef(to) => self.fire_node_ref(to),
             Kind::Return(expr) => self.fire_return(node, expr),
             // Kind::TypeReference(r) => self.traverse_type_reference( node, r),

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -290,7 +290,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 .. /* FIXME: Generics should be empty at this point */
             } => self.fire_call( node, to, args),
             Kind::Binding { to, .. } => self.fire_binding(node, to),
-            Kind::NodeRef(to) => self.fire_node_ref(to),
+            Kind::NodeRef(to) => { self.fire_node_ref(to)?; self.gc.transfer(to, node.origin); KeepGoing },
             Kind::Return(expr) => self.fire_return(node, expr),
             // Kind::TypeReference(r) => self.traverse_type_reference( node, r),
             // Kind::Generic { default } => self.traverse_generic( node, default),

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -334,7 +334,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 .. /* FIXME: Generics should be empty at this point */
             } => self.fire_call( node, to, args),
             Kind::Binding { to } => self.fire_binding( node, to),
-            Kind::TypedValue { value, ty } => self.fire_typed_value( node, value, ty),
+            Kind::NodeRef { value, ty } => self.fire_typed_value( node, value, ty),
             Kind::Return(expr) => self.fire_return( node, expr),
             // Kind::TypeReference(r) => self.traverse_type_reference( node, r),
             // Kind::Generic { default } => self.traverse_generic( node, default),

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -115,11 +115,6 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
         &self.fir.nodes[&r.expect_resolved()]
     }
 
-    // TODO: Rename: `access_origin`?
-    fn access_resolved(&self, resolved: &OriginIdx) -> &'fir Node<FlattenData<'ast>> {
-        &self.fir.nodes[&resolved]
-    }
-
     #[must_use]
     fn fire_block(
         &mut self,

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -191,7 +191,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
             }
             Some(block) => {
                 // here, we handle the firing of the block particularly as we want to catch early returns
-                let result = match self.fire_node_ref(block) {
+                let result = match self.fire_reference(block) {
                     ControlFlow::Break(EarlyExit::Return(returned_value)) => {
                         RefIdx::Resolved(returned_value)
                     }
@@ -213,7 +213,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
         to: &Option<RefIdx>,
     ) -> ControlFlow<EarlyExit> {
         if let Some(to) = to {
-            self.fire_node_ref(to)?;
+            self.fire_reference(to)?;
 
             self.gc.transfer(to, node.origin);
         }
@@ -228,7 +228,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
         expr: &Option<RefIdx>,
     ) -> ControlFlow<EarlyExit> {
         if let Some(returned) = expr {
-            self.fire_node_ref(returned)?;
+            self.fire_reference(returned)?;
 
             self.gc.transfer(returned, node.origin);
         } // FIXME: Allocate None otherwise?
@@ -237,7 +237,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
     }
 
     #[must_use]
-    fn fire_node_ref(&mut self, node_ref: &RefIdx) -> ControlFlow<EarlyExit> {
+    fn fire_reference(&mut self, node_ref: &RefIdx) -> ControlFlow<EarlyExit> {
         self.fire_node(self.access(node_ref))
     }
 
@@ -252,7 +252,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
         let t = Instance::from(true);
         let f = Instance::from(false);
 
-        self.fire_node_ref(condition)?;
+        self.fire_reference(condition)?;
 
         let condition_result = self.gc.lookup(&condition.expect_resolved());
 
@@ -266,7 +266,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
 
         // TODO: Is that correct?
         if let Some(block) = to_run {
-            self.fire_node_ref(block)?;
+            self.fire_reference(block)?;
 
             self.gc.transfer(block, node.origin);
         }
@@ -285,7 +285,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 .. /* FIXME: Generics should be empty at this point */
             } => self.fire_call( node, to, args),
             Kind::Binding { to, .. } => self.fire_binding(node, to),
-            Kind::NodeRef(to) => { self.fire_node_ref(to)?; self.gc.transfer(to, node.origin); KeepGoing },
+            Kind::NodeRef(to) => { self.fire_reference(to)?; self.gc.transfer(to, node.origin); KeepGoing },
             Kind::Return(expr) => self.fire_return(node, expr),
             // Kind::TypeReference(r) => self.traverse_type_reference( node, r),
             // Kind::Generic { default } => self.traverse_generic( node, default),

--- a/fire/src/lib.rs
+++ b/fire/src/lib.rs
@@ -274,6 +274,16 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
         KeepGoing
     }
 
+    fn fire_node_ref(
+        &mut self,
+        node: &Node<FlattenData<'_>>,
+        to: &RefIdx,
+    ) -> ControlFlow<EarlyExit> {
+        self.fire_reference(to)?;
+        self.gc.transfer(to, node.origin);
+        KeepGoing
+    }
+
     #[must_use]
     fn fire_node(&mut self, node: &Node<FlattenData<'_>>) -> ControlFlow<EarlyExit> {
         match &node.kind {
@@ -285,7 +295,7 @@ impl<'ast, 'fir> Fire<'ast, 'fir> {
                 .. /* FIXME: Generics should be empty at this point */
             } => self.fire_call( node, to, args),
             Kind::Binding { to, .. } => self.fire_binding(node, to),
-            Kind::NodeRef(to) => { self.fire_reference(to)?; self.gc.transfer(to, node.origin); KeepGoing },
+            Kind::NodeRef(to) => self.fire_node_ref(node, to),
             Kind::Return(expr) => self.fire_return(node, expr),
             // Kind::TypeReference(r) => self.traverse_type_reference( node, r),
             // Kind::Generic { default } => self.traverse_generic( node, default),

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -372,7 +372,7 @@ impl<'ast> Ctx<'ast> {
             scope: ctx.scope,
         };
 
-        let value = Kind::TypedValue {
+        let value = Kind::NodeRef {
             value: RefIdx::Unresolved,
             ty,
         };
@@ -810,7 +810,7 @@ impl<'ast> Ctx<'ast> {
             ast,
         };
 
-        let kind = Kind::TypedValue {
+        let kind = Kind::NodeRef {
             value: RefIdx::Unresolved,
             ty: RefIdx::Unresolved,
         };
@@ -1019,7 +1019,7 @@ mod tests {
         let x = &fir.nodes.get(&OriginIdx(3)).unwrap().kind;
         let y = &fir.nodes.get(&OriginIdx(4)).unwrap().kind;
 
-        assert!(matches!(x, Kind::TypedValue { .. }));
+        assert!(matches!(x, Kind::NodeRef { .. }));
         assert!(matches!(y, Kind::Binding { .. }));
     }
 }

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -372,7 +372,10 @@ impl<'ast> Ctx<'ast> {
             scope: ctx.scope,
         };
 
-        let kind = Kind::Binding { to: None, ty };
+        let kind = Kind::Binding {
+            to: None,
+            ty: Some(ty),
+        };
 
         ctx.append(data, kind)
     }
@@ -768,12 +771,14 @@ impl<'ast> Ctx<'ast> {
 
         let data = FlattenData {
             scope: ctx.scope,
-            ast,
+            ast: dbg!(ast),
         };
+
+        // FIXME: If there is a given type, we need to handle it here
 
         let kind = Kind::Binding {
             to: Some(to_bind),
-            ty: RefIdx::Unresolved,
+            ty: None,
         };
 
         ctx.append(data, kind)

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -372,15 +372,7 @@ impl<'ast> Ctx<'ast> {
             scope: ctx.scope,
         };
 
-        // let value = Kind::NodeRef {
-        //     value: RefIdx::Unresolved,
-        //     ty,
-        // };
-        // let (ctx, to) = ctx.append(data.clone(), value);
-
-        let kind = Kind::Binding {
-            to: RefIdx::Unresolved,
-        };
+        let kind = Kind::Binding { to: None, ty };
 
         ctx.append(data, kind)
     }
@@ -779,7 +771,10 @@ impl<'ast> Ctx<'ast> {
             ast,
         };
 
-        let kind = Kind::Binding { to: to_bind };
+        let kind = Kind::Binding {
+            to: Some(to_bind),
+            ty: RefIdx::Unresolved,
+        };
 
         ctx.append(data, kind)
     }

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -372,13 +372,15 @@ impl<'ast> Ctx<'ast> {
             scope: ctx.scope,
         };
 
-        let value = Kind::NodeRef {
-            value: RefIdx::Unresolved,
-            ty,
-        };
-        let (ctx, to) = ctx.append(data.clone(), value);
+        // let value = Kind::NodeRef {
+        //     value: RefIdx::Unresolved,
+        //     ty,
+        // };
+        // let (ctx, to) = ctx.append(data.clone(), value);
 
-        let kind = Kind::Binding { to };
+        let kind = Kind::Binding {
+            to: RefIdx::Unresolved,
+        };
 
         ctx.append(data, kind)
     }
@@ -810,10 +812,7 @@ impl<'ast> Ctx<'ast> {
             ast,
         };
 
-        let kind = Kind::NodeRef {
-            value: RefIdx::Unresolved,
-            ty: RefIdx::Unresolved,
-        };
+        let kind = Kind::NodeRef(RefIdx::Unresolved);
 
         self.append(data, kind)
     }

--- a/flatten/src/lib.rs
+++ b/flatten/src/lib.rs
@@ -771,7 +771,7 @@ impl<'ast> Ctx<'ast> {
 
         let data = FlattenData {
             scope: ctx.scope,
-            ast: dbg!(ast),
+            ast,
         };
 
         // FIXME: If there is a given type, we need to handle it here

--- a/interpreter/jinko.rs
+++ b/interpreter/jinko.rs
@@ -154,6 +154,11 @@ fn experimental_pipeline(input: &str, file: &Path) -> InteractResult {
         .display(&fir);
 
     let fir = x_try!(fir.type_check());
+    FirDebug::default()
+        .header("typechecked")
+        .show_data(data_fmt)
+        .display(&fir);
+
     let result = fir.interpret();
 
     let exit_code = match result {

--- a/name_resolve/src/declarator.rs
+++ b/name_resolve/src/declarator.rs
@@ -86,6 +86,7 @@ impl<'ast, 'ctx, 'enclosing> Traversal<FlattenData<'ast>, NameResolutionError>
         &mut self,
         _: &Fir<FlattenData>,
         node: &Node<FlattenData>,
+        _: &Option<RefIdx>,
         _: &RefIdx,
     ) -> Fallible<NameResolutionError> {
         self.define(DefinitionKind::Binding, node)

--- a/name_resolve/src/declarator.rs
+++ b/name_resolve/src/declarator.rs
@@ -87,7 +87,7 @@ impl<'ast, 'ctx, 'enclosing> Traversal<FlattenData<'ast>, NameResolutionError>
         _: &Fir<FlattenData>,
         node: &Node<FlattenData>,
         _: &Option<RefIdx>,
-        _: &RefIdx,
+        _: &Option<RefIdx>,
     ) -> Fallible<NameResolutionError> {
         self.define(DefinitionKind::Binding, node)
     }

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -410,8 +410,8 @@ mod tests {
         let a = &fir.nodes[&OriginIdx(2)];
         let a_reference = &fir.nodes[&OriginIdx(3)];
 
-        assert!(matches!(a_reference.kind, Kind::TypedValue { .. }));
-        let Kind::TypedValue {
+        assert!(matches!(a_reference.kind, Kind::NodeRef { .. }));
+        let Kind::NodeRef {
             value: a_reference, ..
         } = a_reference.kind
         else {
@@ -466,9 +466,9 @@ mod tests {
         let (value, ty) = fir
             .nodes
             .values()
-            .find(|node| matches!(node.kind, Kind::TypedValue { .. }))
+            .find(|node| matches!(node.kind, Kind::NodeRef { .. }))
             .map(|node| match node.kind {
-                Kind::TypedValue { value, ty } => (value, ty),
+                Kind::NodeRef { value, ty } => (value, ty),
                 _ => unreachable!(),
             })
             .unwrap();
@@ -558,12 +558,12 @@ mod tests {
         let marker_2 = dbg!(&fir.nodes[&OriginIdx(2)]);
         let x_value = dbg!(&fir.nodes[&OriginIdx(3)]);
 
-        assert!(matches!(x_value.kind, Kind::TypedValue { .. }));
+        assert!(matches!(x_value.kind, Kind::NodeRef { .. }));
         assert!(matches!(marker_1.kind, Kind::RecordType { .. }));
         assert!(matches!(marker_2.kind, Kind::RecordType { .. }));
 
         match x_value.kind {
-            Kind::TypedValue { value, ty } => {
+            Kind::NodeRef { value, ty } => {
                 assert_eq!(value, ty);
                 assert_eq!(ty, RefIdx::Resolved(marker_2.origin));
                 assert_eq!(value, RefIdx::Resolved(marker_2.origin));

--- a/name_resolve/src/lib.rs
+++ b/name_resolve/src/lib.rs
@@ -411,10 +411,7 @@ mod tests {
         let a_reference = &fir.nodes[&OriginIdx(3)];
 
         assert!(matches!(a_reference.kind, Kind::NodeRef { .. }));
-        let Kind::NodeRef {
-            value: a_reference, ..
-        } = a_reference.kind
-        else {
+        let Kind::NodeRef(a_reference) = a_reference.kind else {
             unreachable!()
         };
 
@@ -463,18 +460,19 @@ mod tests {
             .nodes
             .values()
             .find(|node| matches!(node.kind, Kind::RecordType { .. }));
-        let (value, ty) = fir
+        let value = fir
             .nodes
             .values()
             .find(|node| matches!(node.kind, Kind::NodeRef { .. }))
             .map(|node| match node.kind {
-                Kind::NodeRef { value, ty } => (value, ty),
+                Kind::NodeRef(to) => to,
                 _ => unreachable!(),
             })
             .unwrap();
 
         assert_eq!(value, RefIdx::Resolved(def.unwrap().origin));
-        assert_eq!(ty, RefIdx::Resolved(def.unwrap().origin));
+        // FIXME: Is it okay if we don't typecheck here?
+        // assert_eq!(ty, RefIdx::Resolved(def.unwrap().origin));
     }
 
     #[test]
@@ -563,9 +561,10 @@ mod tests {
         assert!(matches!(marker_2.kind, Kind::RecordType { .. }));
 
         match x_value.kind {
-            Kind::NodeRef { value, ty } => {
-                assert_eq!(value, ty);
-                assert_eq!(ty, RefIdx::Resolved(marker_2.origin));
+            Kind::NodeRef(value) => {
+                // FIXME: Is it okay to not tyck here?
+                // assert_eq!(value, ty);
+                // assert_eq!(ty, RefIdx::Resolved(marker_2.origin));
                 assert_eq!(value, RefIdx::Resolved(marker_2.origin));
             }
             _ => unreachable!(),

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -137,7 +137,7 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         Ok(Node {
             data,
             origin,
-            kind: Kind::TypedValue {
+            kind: Kind::NodeRef {
                 value: RefIdx::Resolved(definition),
                 ty,
             },

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -94,63 +94,51 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         }
     }
 
-    // fn map_typed_value(
-    //     &mut self,
-    //     data: FlattenData<'ast>,
-    //     origin: OriginIdx,
-    //     _value: RefIdx,
-    //     ty: RefIdx,
-    // ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
-    //     let var_def = self.get_definition(
-    //         ResolveKind::Var,
-    //         data.ast.symbol(),
-    //         data.ast.location(),
-    //         origin,
-    //     );
-    //     let ty_def = self.get_definition(
-    //         ResolveKind::Type,
-    //         data.ast.symbol(),
-    //         data.ast.location(),
-    //         origin,
-    //     );
-
-    //     // If we're dealing with a type definition, we can "early typecheck"
-    //     // to the empty type's definition
-    //     let ty = match &ty_def {
-    //         Ok(def) => RefIdx::Resolved(*def),
-    //         Err(_) => ty,
-    //     };
-
-    //     let definition = match (var_def, ty_def) {
-    //         (Ok(var_def), Ok(ty_def)) => Err(NameResolutionError::ambiguous_binding(
-    //             var_def,
-    //             ty_def,
-    //             data.ast.location(),
-    //         )),
-    //         (Err(_), Err(_)) => Err(NameResolutionError::unresolved_binding(
-    //             data.ast.symbol(),
-    //             data.ast.location(),
-    //         )),
-    //         (Ok(def), _) | (_, Ok(def)) => Ok(def),
-    //     }?;
-
-    //     Ok(Node {
-    //         data,
-    //         origin,
-    //         kind: Kind::NodeRef {
-    //             value: RefIdx::Resolved(definition),
-    //             ty,
-    //         },
-    //     })
-    // }
-
     fn map_node_ref(
         &mut self,
         data: FlattenData<'ast>,
         origin: OriginIdx,
-        to: RefIdx,
+        _: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
-        todo!()
+        let var_def = self.get_definition(
+            ResolveKind::Var,
+            data.ast.symbol(),
+            data.ast.location(),
+            origin,
+        );
+        let ty_def = self.get_definition(
+            ResolveKind::Type,
+            data.ast.symbol(),
+            data.ast.location(),
+            origin,
+        );
+
+        // If we're dealing with a type definition, we can "early typecheck"
+        // to the empty type's definition
+        // FIXME: Leave that to the actual typechecker
+        // let ty = match &ty_def {
+        //     Ok(def) => RefIdx::Resolved(*def),
+        //     Err(_) => ty,
+        // };
+
+        let definition = match (var_def, ty_def) {
+            (Ok(var_def), Ok(ty_def)) => Err(NameResolutionError::ambiguous_binding(
+                var_def,
+                ty_def,
+                data.ast.location(),
+            )),
+            (Err(_), Err(_)) => Err(NameResolutionError::unresolved_binding(
+                data.ast.symbol(),
+                data.ast.location(),
+            )),
+            (Ok(def), _) | (_, Ok(def)) => Ok(def),
+        }?;
+
+        Ok(Node {
+            data,
+            origin,
+            kind: Kind::NodeRef(RefIdx::Resolved(definition)),
+        })
     }
 
     fn map_type_reference(

--- a/name_resolve/src/resolver.rs
+++ b/name_resolve/src/resolver.rs
@@ -94,54 +94,63 @@ impl<'ast, 'ctx, 'enclosing> Mapper<FlattenData<'ast>, FlattenData<'ast>, NameRe
         }
     }
 
-    fn map_typed_value(
+    // fn map_typed_value(
+    //     &mut self,
+    //     data: FlattenData<'ast>,
+    //     origin: OriginIdx,
+    //     _value: RefIdx,
+    //     ty: RefIdx,
+    // ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
+    //     let var_def = self.get_definition(
+    //         ResolveKind::Var,
+    //         data.ast.symbol(),
+    //         data.ast.location(),
+    //         origin,
+    //     );
+    //     let ty_def = self.get_definition(
+    //         ResolveKind::Type,
+    //         data.ast.symbol(),
+    //         data.ast.location(),
+    //         origin,
+    //     );
+
+    //     // If we're dealing with a type definition, we can "early typecheck"
+    //     // to the empty type's definition
+    //     let ty = match &ty_def {
+    //         Ok(def) => RefIdx::Resolved(*def),
+    //         Err(_) => ty,
+    //     };
+
+    //     let definition = match (var_def, ty_def) {
+    //         (Ok(var_def), Ok(ty_def)) => Err(NameResolutionError::ambiguous_binding(
+    //             var_def,
+    //             ty_def,
+    //             data.ast.location(),
+    //         )),
+    //         (Err(_), Err(_)) => Err(NameResolutionError::unresolved_binding(
+    //             data.ast.symbol(),
+    //             data.ast.location(),
+    //         )),
+    //         (Ok(def), _) | (_, Ok(def)) => Ok(def),
+    //     }?;
+
+    //     Ok(Node {
+    //         data,
+    //         origin,
+    //         kind: Kind::NodeRef {
+    //             value: RefIdx::Resolved(definition),
+    //             ty,
+    //         },
+    //     })
+    // }
+
+    fn map_node_ref(
         &mut self,
         data: FlattenData<'ast>,
         origin: OriginIdx,
-        _value: RefIdx,
-        ty: RefIdx,
+        to: RefIdx,
     ) -> Result<Node<FlattenData<'ast>>, NameResolutionError> {
-        let var_def = self.get_definition(
-            ResolveKind::Var,
-            data.ast.symbol(),
-            data.ast.location(),
-            origin,
-        );
-        let ty_def = self.get_definition(
-            ResolveKind::Type,
-            data.ast.symbol(),
-            data.ast.location(),
-            origin,
-        );
-
-        // If we're dealing with a type definition, we can "early typecheck"
-        // to the empty type's definition
-        let ty = match &ty_def {
-            Ok(def) => RefIdx::Resolved(*def),
-            Err(_) => ty,
-        };
-
-        let definition = match (var_def, ty_def) {
-            (Ok(var_def), Ok(ty_def)) => Err(NameResolutionError::ambiguous_binding(
-                var_def,
-                ty_def,
-                data.ast.location(),
-            )),
-            (Err(_), Err(_)) => Err(NameResolutionError::unresolved_binding(
-                data.ast.symbol(),
-                data.ast.location(),
-            )),
-            (Ok(def), _) | (_, Ok(def)) => Ok(def),
-        }?;
-
-        Ok(Node {
-            data,
-            origin,
-            kind: Kind::NodeRef {
-                value: RefIdx::Resolved(definition),
-                ty,
-            },
-        })
+        todo!()
     }
 
     fn map_type_reference(

--- a/name_resolve/src/scoper.rs
+++ b/name_resolve/src/scoper.rs
@@ -114,10 +114,7 @@ impl<'ast> Traversal<FlattenData<'ast>, ScoperError> for Scoper {
                 instance: sub_node, ..
             }
             | Kind::Binding { to: sub_node } => self.maybe_visit_child(fir, sub_node),
-            Kind::NodeRef { value, ty } => {
-                self.maybe_visit_child(fir, value)?;
-                self.maybe_visit_child(fir, ty)
-            }
+            Kind::NodeRef(to) => self.maybe_visit_child(fir, to),
             Kind::RecordType { fields: subs, .. } | Kind::UnionType { variants: subs, .. } => {
                 let old = self.enter_scope(node.origin);
 

--- a/name_resolve/src/scoper.rs
+++ b/name_resolve/src/scoper.rs
@@ -111,8 +111,8 @@ impl<'ast> Traversal<FlattenData<'ast>, ScoperError> for Scoper {
 
         match &node.kind {
             Kind::Binding { to, ty } => {
-                to.map_or(Ok(()), |node| self.maybe_visit_child(fir, &node))?;
-                self.maybe_visit_child(fir, ty)
+                to.map_or(Ok(()), |to| self.maybe_visit_child(fir, &to))?;
+                ty.map_or(Ok(()), |ty| self.maybe_visit_child(fir, &ty))
             }
             Kind::TypeReference(sub_node)
             | Kind::TypeOffset {

--- a/name_resolve/src/scoper.rs
+++ b/name_resolve/src/scoper.rs
@@ -114,7 +114,7 @@ impl<'ast> Traversal<FlattenData<'ast>, ScoperError> for Scoper {
                 instance: sub_node, ..
             }
             | Kind::Binding { to: sub_node } => self.maybe_visit_child(fir, sub_node),
-            Kind::TypedValue { value, ty } => {
+            Kind::NodeRef { value, ty } => {
                 self.maybe_visit_child(fir, value)?;
                 self.maybe_visit_child(fir, ty)
             }

--- a/recursive_typecheck/src/lib.rs
+++ b/recursive_typecheck/src/lib.rs
@@ -223,7 +223,7 @@ impl Mapper<FlattenData<'_>, TypeData, Error> for TypeCtx {
         data: FlattenData,
         origin: OriginIdx,
         to: Option<RefIdx>,
-        ty: RefIdx,
+        ty: Option<RefIdx>,
     ) -> Result<Node<TypeData>, Error> {
         // FIXME: What do we do here?
         // A binding declare something that can be looked up, right?

--- a/recursive_typecheck/src/lib.rs
+++ b/recursive_typecheck/src/lib.rs
@@ -154,19 +154,6 @@ impl Mapper<FlattenData<'_>, TypeData, Error> for TypeCtx {
         })
     }
 
-    // fn map_node_ref(
-    //     &mut self,
-    //     data: FlattenData,
-    //     origin: OriginIdx,
-    //     to: RefIdx,
-    // ) -> Result<Node<TypeData>, Error> {
-    // Ok(Node {
-    //     data: TypeData::from(data).uses(ty),
-    //     origin,
-    //     kind: Kind::NodeRef(to),
-    // })
-    // }
-
     fn map_generic(
         &mut self,
         data: FlattenData,

--- a/recursive_typecheck/src/lib.rs
+++ b/recursive_typecheck/src/lib.rs
@@ -154,19 +154,18 @@ impl Mapper<FlattenData<'_>, TypeData, Error> for TypeCtx {
         })
     }
 
-    fn map_typed_value(
-        &mut self,
-        data: FlattenData,
-        origin: OriginIdx,
-        value: RefIdx,
-        ty: RefIdx,
-    ) -> Result<Node<TypeData>, Error> {
-        Ok(Node {
-            data: TypeData::from(data).uses(ty),
-            origin,
-            kind: Kind::NodeRef { value, ty },
-        })
-    }
+    // fn map_node_ref(
+    //     &mut self,
+    //     data: FlattenData,
+    //     origin: OriginIdx,
+    //     to: RefIdx,
+    // ) -> Result<Node<TypeData>, Error> {
+    // Ok(Node {
+    //     data: TypeData::from(data).uses(ty),
+    //     origin,
+    //     kind: Kind::NodeRef(to),
+    // })
+    // }
 
     fn map_generic(
         &mut self,

--- a/recursive_typecheck/src/lib.rs
+++ b/recursive_typecheck/src/lib.rs
@@ -222,16 +222,18 @@ impl Mapper<FlattenData<'_>, TypeData, Error> for TypeCtx {
         &mut self,
         data: FlattenData,
         origin: OriginIdx,
-        to: RefIdx,
+        to: Option<RefIdx>,
+        ty: RefIdx,
     ) -> Result<Node<TypeData>, Error> {
         // FIXME: What do we do here?
         // A binding declare something that can be looked up, right?
         // so which type do we put here? just.. itself? It's a binding
         // to a typed value, correct?
         Ok(Node {
-            data: TypeData::from(data).uses(to),
+            // FIXME: This is wrong
+            data: TypeData::from(data),
             origin,
-            kind: Kind::Binding { to },
+            kind: Kind::Binding { to, ty },
         })
     }
 

--- a/recursive_typecheck/src/lib.rs
+++ b/recursive_typecheck/src/lib.rs
@@ -164,7 +164,7 @@ impl Mapper<FlattenData<'_>, TypeData, Error> for TypeCtx {
         Ok(Node {
             data: TypeData::from(data).uses(ty),
             origin,
-            kind: Kind::TypedValue { value, ty },
+            kind: Kind::NodeRef { value, ty },
         })
     }
 

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -182,7 +182,9 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // These nodes all refer to other nodes, type references or typed values. They will need
             // to be flattened later on.
             fir::Kind::TypeReference(ty)
-            | fir::Kind::Binding { to: ty }
+            // if we have something to bind to, our binding is of this type - otherwise, trust the type
+            | fir::Kind::Binding { to: Some(ty), .. }
+            | fir::Kind::Binding { ty, .. }
             // FIXME: Is that correct? how do we deal with marker types vs bindings?
             | fir::Kind::NodeRef(ty)
             | fir::Kind::Instantiation { to: ty, .. }

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -185,7 +185,6 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // if we have something to bind to, and there is no given type, then our binding is of this type - otherwise, trust the type
             | fir::Kind::Binding { to: Some(ty), .. }
             | fir::Kind::Binding { ty: Some(ty), .. }
-            // FIXME: Is that correct? how do we deal with marker types vs bindings?
             | fir::Kind::NodeRef(ty)
             | fir::Kind::Instantiation { to: ty, .. }
             | fir::Kind::Conditional { true_block: ty, .. } => self.ty(node, ty),
@@ -205,6 +204,8 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             fir::Kind::Generic { .. } | fir::Kind::TypeOffset { .. } | fir::Kind::Loop { .. } => {
                 Ok(node)
             }
+            // Having a binding which has no initial value AND no given type is impossible - at least
+            // for now!
             fir::Kind::Binding { to: None, ty: None } => unreachable!(),
         }
     }

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -182,12 +182,9 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // These nodes all refer to other nodes, type references or typed values. They will need
             // to be flattened later on.
             fir::Kind::TypeReference(ty)
-            | fir::Kind::NodeRef {
-                ty: RefIdx::Unresolved,
-                value: ty,
-            }
             | fir::Kind::Binding { to: ty }
-            | fir::Kind::NodeRef { ty, .. }
+            // FIXME: Is that correct? how do we deal with marker types vs bindings?
+            | fir::Kind::NodeRef(ty)
             | fir::Kind::Instantiation { to: ty, .. }
             | fir::Kind::Conditional { true_block: ty, .. } => self.ty(node, ty),
             // we need to special case `Call`s for arithmetic operators - otherwise, they

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -182,12 +182,12 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // These nodes all refer to other nodes, type references or typed values. They will need
             // to be flattened later on.
             fir::Kind::TypeReference(ty)
-            | fir::Kind::TypedValue {
+            | fir::Kind::NodeRef {
                 ty: RefIdx::Unresolved,
                 value: ty,
             }
             | fir::Kind::Binding { to: ty }
-            | fir::Kind::TypedValue { ty, .. }
+            | fir::Kind::NodeRef { ty, .. }
             | fir::Kind::Instantiation { to: ty, .. }
             | fir::Kind::Conditional { true_block: ty, .. } => self.ty(node, ty),
             // we need to special case `Call`s for arithmetic operators - otherwise, they

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -182,8 +182,8 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // These nodes all refer to other nodes, type references or typed values. They will need
             // to be flattened later on.
             fir::Kind::TypeReference(ty)
-            // if we have something to bind to, our binding is of this type - otherwise, trust the type
-            | fir::Kind::Binding { to: Some(ty), .. }
+            // if we have something to bind to, and there is no given type, then our binding is of this type - otherwise, trust the type
+            | fir::Kind::Binding { to: Some(ty), ty: RefIdx::Unresolved }
             | fir::Kind::Binding { ty, .. }
             // FIXME: Is that correct? how do we deal with marker types vs bindings?
             | fir::Kind::NodeRef(ty)

--- a/typecheck/src/typer.rs
+++ b/typecheck/src/typer.rs
@@ -183,8 +183,8 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             // to be flattened later on.
             fir::Kind::TypeReference(ty)
             // if we have something to bind to, and there is no given type, then our binding is of this type - otherwise, trust the type
-            | fir::Kind::Binding { to: Some(ty), ty: RefIdx::Unresolved }
-            | fir::Kind::Binding { ty, .. }
+            | fir::Kind::Binding { to: Some(ty), .. }
+            | fir::Kind::Binding { ty: Some(ty), .. }
             // FIXME: Is that correct? how do we deal with marker types vs bindings?
             | fir::Kind::NodeRef(ty)
             | fir::Kind::Instantiation { to: ty, .. }
@@ -205,6 +205,7 @@ impl<'ast, 'ctx> Mapper<FlattenData<'ast>, FlattenData<'ast>, Error> for Typer<'
             fir::Kind::Generic { .. } | fir::Kind::TypeOffset { .. } | fir::Kind::Loop { .. } => {
                 Ok(node)
             }
+            fir::Kind::Binding { to: None, ty: None } => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Fixes #661 

Can we actually remove `ValueRef`/`TypedValue`? I don't think we need it, since we should just be able to keep a `RefIdx` of a binding.

- [x] Fix missing typing of bindings 
- [x] Fix missing type-checking of bindings 